### PR TITLE
fix: resurrect anvil ps command

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -59,8 +59,7 @@ func main() {
 	case "status":
 		statusCmd()
 	case "ps":
-		fmt.Fprintln(os.Stderr, "'anvil ps' has been removed. Did you mean 'anvil task ls'?")
-		os.Exit(1)
+		psCmd()
 	case "init":
 		initCmd(os.Args[2:])
 	case "add":
@@ -110,6 +109,7 @@ Commands:
   watch --stop             Stop the background daemon
   add [options] <task>     Add a task to the current project
   logs [<name>]            Raw worker output (all tasks if no name given)
+  ps                       Show running tasks
   status                   Show watched projects
   stop-on-idle             Drain running tasks then exit the daemon
   task <subcommand>        Task management commands


### PR DESCRIPTION
## Summary
- Re-enable the `anvil ps` command that was removed and replaced with a deprecation error
- The underlying `psCmd()` function was still intact — this reconnects the routing in the main switch-case
- Adds `ps` back to the help text output

Closes #108

## Test plan
- [x] `anvil ps` shows running tasks (tested locally)
- [x] `anvil help` lists `ps` command
- [x] `go build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)