### PR TITLE
feat: persist daemon logs to file with rotation

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -78,6 +78,8 @@ func main() {
 		os.Exit(1)
 	case "logs":
 		logsCmd(os.Args[2:])
+	case "daemon":
+		daemonCmd(os.Args[2:])
 	case "stop-on-idle":
 		stopOnIdleCmd()
 	case "task":
@@ -114,6 +116,7 @@ Commands:
   stop-on-idle             Drain running tasks then exit the daemon
   task <subcommand>        Task management commands
   project <subcommand>     Project management commands
+  daemon <subcommand>      Daemon management commands
   update [--check]         Update anvil to the latest release
   version                  Show version
 
@@ -142,6 +145,9 @@ Project subcommands:
   ls [-a|--all]            List watched projects
   get [path]               Show project details and running tasks
   rm [path] [--clean]      Unwatch a project (--clean removes .anvil/ too)
+
+Daemon subcommands:
+  log [-f] [-n lines]    View daemon log (-f to follow, -n for last N lines)
 
 Configuration:
   ~/.anvil/config.yaml   Daemon config
@@ -1775,6 +1781,135 @@ func taskEditCmd(args []string) {
 	}
 
 	fmt.Printf("edited: %s\n", todo.Name)
+}
+
+func daemonCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: anvil daemon <subcommand>")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Subcommands:")
+		fmt.Fprintln(os.Stderr, "  log [-f] [-n lines]   View daemon log (-f to follow, -n for last N lines)")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "log":
+		daemonLogCmd(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown daemon subcommand: %s\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func daemonLogCmd(args []string) {
+	follow := false
+	numLines := 50
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-f", "--follow":
+			follow = true
+		case "-n":
+			if i+1 >= len(args) {
+				log.Fatal("missing value for -n")
+			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n < 0 {
+				log.Fatalf("invalid line count: %s", args[i])
+			}
+			numLines = n
+		case "-h", "--help":
+			fmt.Fprintf(os.Stderr, `usage: anvil daemon log [-f] [-n lines]
+
+View the daemon log file (~/.anvil/daemon.log).
+
+Options:
+  -f, --follow   Follow the log (like tail -f)
+  -n lines       Show last N lines (default 50)
+`)
+			os.Exit(0)
+		}
+	}
+
+	logPath := config.DaemonLogPath()
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		fmt.Fprintln(os.Stderr, "no daemon log found (daemon has not run yet)")
+		os.Exit(1)
+	}
+
+	// Read and display the last N lines.
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		log.Fatalf("failed to read daemon log: %v", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	// Remove trailing empty line from Split.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	start := 0
+	if len(lines) > numLines {
+		start = len(lines) - numLines
+	}
+	for _, line := range lines[start:] {
+		fmt.Println(line)
+	}
+
+	if !follow {
+		return
+	}
+
+	// Follow mode: tail the file for new content.
+	f, err := os.Open(logPath)
+	if err != nil {
+		log.Fatalf("failed to open daemon log: %v", err)
+	}
+	defer f.Close()
+
+	// Seek to end.
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		log.Fatalf("failed to seek: %v", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-sigCh:
+			return
+		default:
+		}
+
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			os.Stdout.Write(buf[:n])
+			continue
+		}
+		if readErr != nil && readErr != io.EOF {
+			return
+		}
+
+		// Check if the file was rotated (new file at same path).
+		newInfo, statErr := os.Stat(logPath)
+		if statErr == nil {
+			curInfo, _ := f.Stat()
+			if curInfo != nil && !os.SameFile(curInfo, newInfo) {
+				// File was rotated — reopen.
+				f.Close()
+				f, err = os.Open(logPath)
+				if err != nil {
+					return
+				}
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 func stopOnIdleCmd() {

--- a/internal/daemon/logger.go
+++ b/internal/daemon/logger.go
@@ -3,7 +3,11 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"sync"
 	"time"
+
+	"github.com/johnjansen/anvil/internal/config"
 )
 
 // ANSI escape sequences
@@ -26,8 +30,18 @@ var workerColors = []string{ansiCyan, ansiYellow, ansiGreen, ansiMagenta, ansiBl
 // priorityColors maps priority level to ANSI code; p3+ uses empty (default)
 var priorityColors = []string{ansiRed, ansiYellow, ansiCyan, ""}
 
+// ansiPattern matches ANSI escape sequences for stripping from log file output.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// maxLogSize is the size threshold at which the daemon log is rotated.
+const maxLogSize = 1 << 20 // 1 MB
+
 type daemonLogger struct {
 	isTTY bool
+
+	mu      sync.Mutex
+	logFile *os.File
+	logSize int64
 }
 
 // dlog is the package-level structured logger for the daemon.
@@ -36,7 +50,55 @@ var dlog = newDaemonLogger()
 func newDaemonLogger() *daemonLogger {
 	fi, err := os.Stdout.Stat()
 	tty := err == nil && (fi.Mode()&os.ModeCharDevice) != 0
-	return &daemonLogger{isTTY: tty}
+	l := &daemonLogger{isTTY: tty}
+	l.openLogFile()
+	return l
+}
+
+// openLogFile opens (or re-opens) the daemon log file for appending.
+// It skips opening if stdout is already pointing at daemon.log (daemonized mode),
+// since the content would be duplicated.
+func (l *daemonLogger) openLogFile() {
+	if err := config.EnsureDir(); err != nil {
+		return
+	}
+	path := config.DaemonLogPath()
+
+	// When daemonized, stdout is redirected to daemon.log by the parent process.
+	// Detect this to avoid writing each line twice.
+	if stdoutInfo, err := os.Stdout.Stat(); err == nil {
+		if logInfo, err := os.Stat(path); err == nil {
+			if os.SameFile(stdoutInfo, logInfo) {
+				return
+			}
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return
+	}
+	l.logFile = f
+	l.logSize = info.Size()
+}
+
+// rotateIfNeeded rotates the log file when it exceeds maxLogSize.
+// Caller must hold l.mu.
+func (l *daemonLogger) rotateIfNeeded() {
+	if l.logFile == nil || l.logSize < maxLogSize {
+		return
+	}
+	l.logFile.Close()
+	path := config.DaemonLogPath()
+	_ = os.Rename(path, path+".1")
+	l.logFile = nil
+	l.logSize = 0
+	l.openLogFile()
 }
 
 // c wraps text in an ANSI color code, stripping it when not a TTY.
@@ -71,6 +133,16 @@ func (l *daemonLogger) ts() string {
 
 func (l *daemonLogger) println(line string) {
 	fmt.Fprintln(os.Stdout, line)
+
+	// Write a plain (no ANSI) copy to the log file.
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.logFile != nil {
+		plain := ansiPattern.ReplaceAllString(line, "") + "\n"
+		n, _ := l.logFile.WriteString(plain)
+		l.logSize += int64(n)
+		l.rotateIfNeeded()
+	}
 }
 
 // --- Daemon lifecycle ---


### PR DESCRIPTION
## Summary

- Daemon logger now writes all output to `~/.anvil/daemon.log` (ANSI-stripped) in addition to stdout
- Size-based log rotation at 1MB (rotates to `daemon.log.1`)
- Detects when stdout is already redirected to `daemon.log` (daemonized `--child` mode) to avoid duplicate writes
- Adds `anvil daemon log [-f] [-n lines]` CLI command to view/tail the daemon log

Closes #105

## Test plan

- [x] Build passes (`go build ./...`)
- [x] `go vet ./...` passes
- [x] `anvil daemon log -n 3` shows last 3 lines of daemon log
- [x] `anvil daemon log -f` follows the log file (SIGINT to exit)
- [x] `anvil daemon log -h` shows help text
- [x] `anvil daemon` (no subcommand) shows usage
- [x] Log file rotation triggers when file exceeds 1MB
- [x] ANSI escape sequences are stripped from file output
- [x] No duplicate writes when daemon is running in daemonized mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)