### PR TITLE
feat: track and report LLM token usage and estimated cost per task

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -86,6 +86,8 @@ func main() {
 		taskCmd(os.Args[2:])
 	case "project":
 		projectCmd(os.Args[2:])
+	case "usage":
+		usageCmd(os.Args[2:])
 	case "update":
 		updateCmd(os.Args[2:])
 	case "reload":
@@ -116,6 +118,7 @@ Commands:
   ps                       Show running tasks
   status                   Show watched projects
   reload                   Reload daemon configuration (SIGHUP)
+  usage [options]           Show LLM token usage and estimated costs
   stop-on-idle             Drain running tasks then exit the daemon
   task <subcommand>        Task management commands
   project <subcommand>     Project management commands
@@ -3004,6 +3007,247 @@ func updateCmd(args []string) {
 	}
 
 	fmt.Printf("updated to %s\n", latest)
+}
+
+func usageCmd(args []string) {
+	var projectFilter string
+	var taskFilter string
+	var sinceStr string
+
+	i := 0
+	for i < len(args) {
+		switch args[i] {
+		case "--project":
+			if i+1 < len(args) {
+				projectFilter = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintln(os.Stderr, "--project requires a value")
+				os.Exit(1)
+			}
+		case "--task":
+			if i+1 < len(args) {
+				taskFilter = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintln(os.Stderr, "--task requires a value")
+				os.Exit(1)
+			}
+		case "--since":
+			if i+1 < len(args) {
+				sinceStr = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintln(os.Stderr, "--since requires a value")
+				os.Exit(1)
+			}
+		case "-h", "--help":
+			fmt.Fprintf(os.Stderr, `Usage: anvil usage [options]
+
+Show LLM token usage and estimated costs across tasks and projects.
+
+Options:
+  --project <path>   Filter to a specific project (default: all watched projects)
+  --task <name>      Filter to a specific task name
+  --since <date>     Show usage since date (YYYY-MM-DD, default: 7 days ago)
+`)
+			os.Exit(0)
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	// Default: last 7 days
+	since := time.Now().AddDate(0, 0, -7)
+	if sinceStr != "" {
+		parsed, err := time.Parse("2006-01-02", sinceStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid date %q (expected YYYY-MM-DD): %v\n", sinceStr, err)
+			os.Exit(1)
+		}
+		since = parsed
+	}
+
+	// Resolve project filter to absolute path
+	if projectFilter != "" {
+		abs, err := filepath.Abs(projectFilter)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad project path: %v\n", err)
+			os.Exit(1)
+		}
+		projectFilter = abs
+	}
+
+	// Discover projects
+	var projectPaths []string
+	if projectFilter != "" {
+		projectPaths = []string{projectFilter}
+	} else {
+		watched, err := loadAllWatched()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to load watched projects: %v\n", err)
+			os.Exit(1)
+		}
+		for _, w := range watched {
+			projectPaths = append(projectPaths, w.Path)
+		}
+	}
+
+	if len(projectPaths) == 0 {
+		fmt.Println("No watched projects found.")
+		return
+	}
+
+	// Load global config for cost rates
+	cfg, _ := config.Load()
+	inputRate := cfg.InputTokenRate
+	outputRate := cfg.OutputTokenRate
+	if inputRate <= 0 {
+		inputRate = 3.0
+	}
+	if outputRate <= 0 {
+		outputRate = 15.0
+	}
+
+	type taskUsage struct {
+		Project      string
+		TaskName     string
+		Runs         int
+		InputTokens  int
+		OutputTokens int
+		Cost         float64
+	}
+
+	var allUsage []taskUsage
+	var totalRuns int
+	var totalInput, totalOutput int
+	var totalCost float64
+
+	for _, projPath := range projectPaths {
+		proj, err := project.Load(projPath)
+		if err != nil {
+			continue
+		}
+		todos, err := proj.LoadTodos()
+		if err != nil {
+			continue
+		}
+		projName := filepath.Base(projPath)
+
+		for _, todo := range todos {
+			if taskFilter != "" && todo.Name != taskFilter {
+				continue
+			}
+			records, err := project.ReadAllRunRecords(projPath, todo.ID)
+			if err != nil {
+				continue
+			}
+
+			var tu taskUsage
+			tu.Project = projName
+			tu.TaskName = todo.Name
+
+			for _, rec := range records {
+				if rec.Started.Before(since) {
+					continue
+				}
+				tu.Runs++
+				tu.InputTokens += rec.InputTokens
+				tu.OutputTokens += rec.OutputTokens
+				tu.Cost += rec.EstimatedCostUSD
+			}
+
+			// Recalculate cost if records had zero cost but had tokens
+			// (handles old records that may have tokens but no cost)
+			if tu.Cost == 0 && (tu.InputTokens > 0 || tu.OutputTokens > 0) {
+				tu.Cost = float64(tu.InputTokens)/1_000_000*inputRate +
+					float64(tu.OutputTokens)/1_000_000*outputRate
+			}
+
+			if tu.Runs > 0 {
+				allUsage = append(allUsage, tu)
+				totalRuns += tu.Runs
+				totalInput += tu.InputTokens
+				totalOutput += tu.OutputTokens
+				totalCost += tu.Cost
+			}
+		}
+	}
+
+	if totalRuns == 0 {
+		fmt.Printf("No runs found since %s.\n", since.Format("2006-01-02"))
+		return
+	}
+
+	// Sort by cost descending
+	sort.Slice(allUsage, func(i, j int) bool {
+		return allUsage[i].Cost > allUsage[j].Cost
+	})
+
+	// Print summary
+	fmt.Printf("Token usage since %s\n", since.Format("2006-01-02"))
+	fmt.Printf("Rates: $%.2f/1M input, $%.2f/1M output\n\n", inputRate, outputRate)
+
+	fmt.Printf("%-30s %-6s %12s %12s %10s\n", "TASK", "RUNS", "INPUT", "OUTPUT", "COST")
+	fmt.Printf("%-30s %-6s %12s %12s %10s\n", "----", "----", "-----", "------", "----")
+
+	limit := len(allUsage)
+	if limit > 15 {
+		limit = 15
+	}
+	for _, tu := range allUsage[:limit] {
+		name := tu.TaskName
+		if len(name) > 27 {
+			name = name[:27] + "..."
+		}
+		if len(projectPaths) > 1 {
+			label := tu.Project + "/" + name
+			if len(label) > 30 {
+				label = label[:27] + "..."
+			}
+			name = label
+		}
+		fmt.Printf("%-30s %-6d %12s %12s %10s\n",
+			name,
+			tu.Runs,
+			formatTokens(tu.InputTokens),
+			formatTokens(tu.OutputTokens),
+			formatCost(tu.Cost))
+	}
+	if len(allUsage) > limit {
+		fmt.Printf("  ... and %d more tasks\n", len(allUsage)-limit)
+	}
+
+	fmt.Printf("\n%-30s %-6d %12s %12s %10s\n",
+		"TOTAL",
+		totalRuns,
+		formatTokens(totalInput),
+		formatTokens(totalOutput),
+		formatCost(totalCost))
+}
+
+func formatTokens(n int) string {
+	if n == 0 {
+		return "N/A"
+	}
+	if n >= 1_000_000 {
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+	if n >= 1_000 {
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func formatCost(c float64) string {
+	if c == 0 {
+		return "N/A"
+	}
+	if c < 0.01 {
+		return fmt.Sprintf("$%.4f", c)
+	}
+	return fmt.Sprintf("$%.2f", c)
 }
 
 // --- helpers ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,13 +10,15 @@ import (
 )
 
 type Config struct {
-	TickInterval time.Duration `yaml:"tick_interval"`
-	Runner       string        `yaml:"runner"`
-	Runners      []string      `yaml:"runners"`
-	Timeout      time.Duration `yaml:"timeout"`
-	MaxWorkers   int           `yaml:"max_workers"`
-	MaxTodos     int           `yaml:"max_todos"` // deprecated: use max_workers
-	Hooks        HooksConfig   `yaml:"hooks"`
+	TickInterval    time.Duration `yaml:"tick_interval"`
+	Runner          string        `yaml:"runner"`
+	Runners         []string      `yaml:"runners"`
+	Timeout         time.Duration `yaml:"timeout"`
+	MaxWorkers      int           `yaml:"max_workers"`
+	MaxTodos        int           `yaml:"max_todos"` // deprecated: use max_workers
+	Hooks           HooksConfig   `yaml:"hooks"`
+	InputTokenRate  float64       `yaml:"input_token_rate"`  // cost per 1M input tokens in USD (default: 3.0)
+	OutputTokenRate float64       `yaml:"output_token_rate"` // cost per 1M output tokens in USD (default: 15.0)
 }
 
 // HooksConfig defines global lifecycle hooks that run for all tasks.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -487,6 +487,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 	var usedSessionID string
 	var logPath string
 	var usedRunnerIdx int
+	var stderrOutput string
 	var err error
 
 	for attempt := 0; ; attempt++ {
@@ -496,7 +497,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 			break
 		}
 
-		usedSessionID, logPath, usedRunnerIdx, err = d.runner.Run(ctx, proj.Path, sessionToResume, resume, t.SkipPermissions, t.AllowedTools, t.Content, taskLabel, logDir, skipIndices, func(pid int, lp string, sid string) {
+		usedSessionID, logPath, usedRunnerIdx, stderrOutput, err = d.runner.Run(ctx, proj.Path, sessionToResume, resume, t.SkipPermissions, t.AllowedTools, t.Content, taskLabel, logDir, skipIndices, func(pid int, lp string, sid string) {
 			childPID = pid
 			d.tasksMu.Lock()
 			if task, ok := d.tasks[taskKey]; ok {
@@ -563,15 +564,33 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 		}
 	}
 
+	// Parse token usage from runner stderr
+	tokenUsage := runner.ParseTokenUsage(stderrOutput)
+
+	// Calculate estimated cost using configured or default rates
+	inputRate := d.config.InputTokenRate
+	outputRate := d.config.OutputTokenRate
+	if inputRate <= 0 {
+		inputRate = 3.0 // $3.00 per 1M input tokens (Sonnet default)
+	}
+	if outputRate <= 0 {
+		outputRate = 15.0 // $15.00 per 1M output tokens (Sonnet default)
+	}
+	estimatedCost := float64(tokenUsage.InputTokens)/1_000_000*inputRate +
+		float64(tokenUsage.OutputTokens)/1_000_000*outputRate
+
 	// Write run record after completion with outcome data
 	runRecord := project.RunRecord{
-		RunID:     runID,
-		TaskID:    t.ID,
-		SessionID: usedSessionID,
-		PID:       childPID,
-		Started:   startTime,
-		Finished:  time.Now(),
-		Success:   err == nil,
+		RunID:            runID,
+		TaskID:           t.ID,
+		SessionID:        usedSessionID,
+		PID:              childPID,
+		Started:          startTime,
+		Finished:         time.Now(),
+		Success:          err == nil,
+		InputTokens:      tokenUsage.InputTokens,
+		OutputTokens:     tokenUsage.OutputTokens,
+		EstimatedCostUSD: estimatedCost,
 	}
 	if err != nil {
 		runRecord.Error = err.Error()

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -94,15 +94,18 @@ type Todo struct {
 // RunRecord persists metadata for a single task dispatch, written after completion.
 // It links a task ID to the Claude session ID and child process PID used for that run.
 type RunRecord struct {
-	RunID         string    `json:"run_id"`
-	TaskID        string    `json:"task_id"`
-	SessionID     string    `json:"session_id"`
-	PID           int       `json:"pid"`
-	Started       time.Time `json:"started"`
-	Finished      time.Time `json:"finished,omitempty"`       // when the run ended
-	Success       bool      `json:"success"`                  // whether the runner returned nil error
-	OutputSummary string    `json:"output_summary,omitempty"` // first and last N lines of output
-	Error         string    `json:"error,omitempty"`           // last runner error message if failed
+	RunID            string    `json:"run_id"`
+	TaskID           string    `json:"task_id"`
+	SessionID        string    `json:"session_id"`
+	PID              int       `json:"pid"`
+	Started          time.Time `json:"started"`
+	Finished         time.Time `json:"finished,omitempty"`        // when the run ended
+	Success          bool      `json:"success"`                   // whether the runner returned nil error
+	OutputSummary    string    `json:"output_summary,omitempty"`  // first and last N lines of output
+	Error            string    `json:"error,omitempty"`           // last runner error message if failed
+	InputTokens      int       `json:"input_tokens,omitempty"`    // tokens sent to the model
+	OutputTokens     int       `json:"output_tokens,omitempty"`   // tokens received from the model
+	EstimatedCostUSD float64   `json:"estimated_cost_usd,omitempty"` // estimated cost in USD
 }
 
 // Load reads a project's .anvil/config.yaml and returns a Project.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -48,8 +49,9 @@ func New(commands []string, timeout time.Duration) *Runner {
 //
 // Returns the actual session ID used (either the passed-in sessionID for resume,
 // or a freshly generated one), the log file path (empty if no log was written),
-// the index of the runner that was used (last attempted, -1 if none), and any error.
-func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume bool, skipPermissions bool, allowedTools []string, content string, taskLabel string, logDir string, skipIndices map[int]bool, onStart func(pid int, logPath string, sessionID string), onStatus func(status string)) (usedSessionID string, logPath string, usedRunnerIndex int, err error) {
+// the index of the runner that was used (last attempted, -1 if none), the stderr
+// output from the last runner attempt (used for token usage parsing), and any error.
+func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume bool, skipPermissions bool, allowedTools []string, content string, taskLabel string, logDir string, skipIndices map[int]bool, onStart func(pid int, logPath string, sessionID string), onStatus func(status string)) (usedSessionID string, logPath string, usedRunnerIndex int, stderrOutput string, err error) {
 	var lastErr error
 	var lastStderr string
 	var lastRunnerIndex int
@@ -152,7 +154,7 @@ func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume b
 		}
 		if waitErr != nil {
 			if ctx.Err() == context.DeadlineExceeded {
-				return "", logPath, i, fmt.Errorf("timed out after %s", r.Timeout)
+				return "", logPath, i, stderr.String(), fmt.Errorf("timed out after %s", r.Timeout)
 			}
 			lastErr = waitErr
 			lastStderr = stderr.String()
@@ -162,10 +164,10 @@ func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume b
 		}
 
 		log.Printf("runner[%d] [%s] succeeded: %s", i, taskLabel, command)
-		return actualSessionID, logPath, i, nil
+		return actualSessionID, logPath, i, stderr.String(), nil
 	}
 
-	return "", logPath, lastRunnerIndex, fmt.Errorf("all runners failed: last exit error: %w\nstderr: %s", lastErr, lastStderr)
+	return "", logPath, lastRunnerIndex, lastStderr, fmt.Errorf("all runners failed: last exit error: %w\nstderr: %s", lastErr, lastStderr)
 }
 
 // cleanEnv returns the current environment with Claude-nesting guard vars removed.
@@ -251,6 +253,58 @@ func (sw *statusWriter) Flush() {
 		}
 		sw.buf = nil
 	}
+}
+
+// TokenUsage holds parsed token counts from Claude CLI stderr output.
+type TokenUsage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// ParseTokenUsage extracts token usage from Claude CLI stderr output.
+// Claude CLI prints usage stats like:
+//
+//	Total input tokens: 12345
+//	Total output tokens: 6789
+//
+// or in cost format:
+//
+//	Input tokens: 12345
+//	Output tokens: 6789
+//
+// Returns zero values if parsing fails (caller should treat as "N/A").
+func ParseTokenUsage(stderr string) TokenUsage {
+	var usage TokenUsage
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if n, ok := extractTokenCount(line, "input"); ok {
+			usage.InputTokens = n
+		}
+		if n, ok := extractTokenCount(line, "output"); ok {
+			usage.OutputTokens = n
+		}
+	}
+	return usage
+}
+
+// extractTokenCount tries to extract a token count from a line containing
+// the given direction ("input" or "output"). It handles various formats
+// that Claude CLI may use to report token counts.
+func extractTokenCount(line, direction string) (int, bool) {
+	lower := strings.ToLower(line)
+	if !strings.Contains(lower, direction) || !strings.Contains(lower, "token") {
+		return 0, false
+	}
+	// Extract the last number on the line (the token count)
+	parts := strings.Fields(line)
+	for i := len(parts) - 1; i >= 0; i-- {
+		// Strip commas from numbers like "12,345"
+		cleaned := strings.ReplaceAll(parts[i], ",", "")
+		if n, err := strconv.Atoi(cleaned); err == nil && n >= 0 {
+			return n, true
+		}
+	}
+	return 0, false
 }
 
 // shellEscape wraps content in single quotes with proper escaping.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestParseTokenUsage_StandardFormat(t *testing.T) {
+	stderr := `Some startup output
+Total input tokens: 12345
+Total output tokens: 6789
+Done.`
+	usage := ParseTokenUsage(stderr)
+	if usage.InputTokens != 12345 {
+		t.Errorf("expected InputTokens=12345, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 6789 {
+		t.Errorf("expected OutputTokens=6789, got %d", usage.OutputTokens)
+	}
+}
+
+func TestParseTokenUsage_WithCommas(t *testing.T) {
+	stderr := `Input tokens: 1,234,567
+Output tokens: 89,012`
+	usage := ParseTokenUsage(stderr)
+	if usage.InputTokens != 1234567 {
+		t.Errorf("expected InputTokens=1234567, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 89012 {
+		t.Errorf("expected OutputTokens=89012, got %d", usage.OutputTokens)
+	}
+}
+
+func TestParseTokenUsage_NoTokenInfo(t *testing.T) {
+	stderr := `Some random error output
+No token info here`
+	usage := ParseTokenUsage(stderr)
+	if usage.InputTokens != 0 {
+		t.Errorf("expected InputTokens=0, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 0 {
+		t.Errorf("expected OutputTokens=0, got %d", usage.OutputTokens)
+	}
+}
+
+func TestParseTokenUsage_EmptyStderr(t *testing.T) {
+	usage := ParseTokenUsage("")
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+		t.Errorf("expected zero values for empty stderr, got %+v", usage)
+	}
+}
+
+func TestParseTokenUsage_CaseInsensitive(t *testing.T) {
+	stderr := `TOTAL INPUT TOKENS: 500
+TOTAL OUTPUT TOKENS: 200`
+	usage := ParseTokenUsage(stderr)
+	if usage.InputTokens != 500 {
+		t.Errorf("expected InputTokens=500, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 200 {
+		t.Errorf("expected OutputTokens=200, got %d", usage.OutputTokens)
+	}
+}
+
+func TestParseTokenUsage_MixedContent(t *testing.T) {
+	stderr := `Starting task...
+⠋ Running...
+input tokens: 42000
+some other line
+output tokens: 8500
+Finished.`
+	usage := ParseTokenUsage(stderr)
+	if usage.InputTokens != 42000 {
+		t.Errorf("expected InputTokens=42000, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 8500 {
+		t.Errorf("expected OutputTokens=8500, got %d", usage.OutputTokens)
+	}
+}
+
+func TestExtractTokenCount_Direction(t *testing.T) {
+	// Should not match "output" when looking for "input"
+	n, ok := extractTokenCount("output tokens: 500", "input")
+	if ok {
+		t.Errorf("should not match output line for input direction, got %d", n)
+	}
+
+	n, ok = extractTokenCount("input tokens: 500", "input")
+	if !ok || n != 500 {
+		t.Errorf("expected 500, got %d (ok=%v)", n, ok)
+	}
+}


### PR DESCRIPTION
## Summary

- Parses Claude CLI stderr for token counts (input/output) after each task run
- Extends `RunRecord` with `input_tokens`, `output_tokens`, and `estimated_cost_usd` fields (backwards-compatible with old records)
- Adds `input_token_rate` and `output_token_rate` to global config (`~/.anvil/config.yaml`) with Sonnet defaults ($3/$15 per 1M tokens)
- New `anvil usage` command showing aggregated token usage and costs across all projects

### `anvil usage` options
```
anvil usage                    # all projects, last 7 days
anvil usage --project .        # current project only
anvil usage --task <name>      # specific task
anvil usage --since 2025-01-01 # custom date range
```

### Files changed
- `internal/project/project.go` — extended `RunRecord` with token fields
- `internal/runner/runner.go` — added `ParseTokenUsage()` to extract token counts from stderr; modified `Run()` to return stderr output
- `internal/daemon/daemon.go` — parses tokens after each run, calculates cost, stores in run record
- `internal/config/config.go` — added `input_token_rate` / `output_token_rate` config fields
- `cmd/anvil/main.go` — implemented `anvil usage` command with `--project`, `--task`, `--since` flags

## Test plan

- [x] Added 7 unit tests for token parsing (standard format, commas, empty, case-insensitive, mixed content, direction filtering)
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [ ] Manual test: run a task and verify run record includes token counts
- [ ] Manual test: `anvil usage` displays correct aggregation

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)