### PR TITLE
fix: detect ##anvil:status on stderr in addition to stdout

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -125,15 +125,19 @@ func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume b
 
 		var stdout, stderr bytes.Buffer
 		var sw *statusWriter
+		var stderrSw *statusWriter
 		if logFile != nil {
 			stdoutBase := io.MultiWriter(&stdout, logFile)
 			sw = newStatusWriter(stdoutBase, onStatus)
 			cmd.Stdout = sw
-			cmd.Stderr = io.MultiWriter(&stderr, logFile)
+			stderrBase := io.MultiWriter(&stderr, logFile)
+			stderrSw = newStatusWriter(stderrBase, onStatus)
+			cmd.Stderr = stderrSw
 		} else {
 			sw = newStatusWriter(&stdout, onStatus)
 			cmd.Stdout = sw
-			cmd.Stderr = &stderr
+			stderrSw = newStatusWriter(&stderr, onStatus)
+			cmd.Stderr = stderrSw
 		}
 
 		if err := cmd.Start(); err != nil {
@@ -151,6 +155,9 @@ func (r *Runner) Run(ctx context.Context, dir string, sessionID string, resume b
 		waitErr := cmd.Wait()
 		if sw != nil {
 			sw.Flush()
+		}
+		if stderrSw != nil {
+			stderrSw.Flush()
 		}
 		if waitErr != nil {
 			if ctx.Err() == context.DeadlineExceeded {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"bytes"
+	"sync"
 	"testing"
 )
 
@@ -87,5 +89,123 @@ func TestExtractTokenCount_Direction(t *testing.T) {
 	n, ok = extractTokenCount("input tokens: 500", "input")
 	if !ok || n != 500 {
 		t.Errorf("expected 500, got %d (ok=%v)", n, ok)
+	}
+}
+
+func TestStatusWriter_DetectsStatusOnStdout(t *testing.T) {
+	var downstream bytes.Buffer
+	var mu sync.Mutex
+	var captured string
+
+	sw := newStatusWriter(&downstream, func(status string) {
+		mu.Lock()
+		captured = status
+		mu.Unlock()
+	})
+
+	sw.Write([]byte("normal output\n##anvil:status working on tests\nmore output\n"))
+	sw.Flush()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if captured != "working on tests" {
+		t.Errorf("expected status 'working on tests', got %q", captured)
+	}
+
+	// Status lines should be stripped from downstream
+	if bytes.Contains(downstream.Bytes(), []byte("##anvil:status")) {
+		t.Error("status line should be stripped from downstream output")
+	}
+
+	// Non-status lines should pass through
+	if !bytes.Contains(downstream.Bytes(), []byte("normal output")) {
+		t.Error("normal output should pass through")
+	}
+	if !bytes.Contains(downstream.Bytes(), []byte("more output")) {
+		t.Error("more output should pass through")
+	}
+}
+
+func TestStatusWriter_MultipleStatusUpdates(t *testing.T) {
+	var downstream bytes.Buffer
+	var mu sync.Mutex
+	var statuses []string
+
+	sw := newStatusWriter(&downstream, func(status string) {
+		mu.Lock()
+		statuses = append(statuses, status)
+		mu.Unlock()
+	})
+
+	sw.Write([]byte("##anvil:status step 1\n"))
+	sw.Write([]byte("##anvil:status step 2\n"))
+	sw.Write([]byte("##anvil:status step 3\n"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(statuses) != 3 {
+		t.Fatalf("expected 3 status updates, got %d", len(statuses))
+	}
+	if statuses[2] != "step 3" {
+		t.Errorf("expected last status 'step 3', got %q", statuses[2])
+	}
+}
+
+func TestStatusWriter_PartialLineBuffering(t *testing.T) {
+	var downstream bytes.Buffer
+	var mu sync.Mutex
+	var captured string
+
+	sw := newStatusWriter(&downstream, func(status string) {
+		mu.Lock()
+		captured = status
+		mu.Unlock()
+	})
+
+	// Write status prefix split across two Write calls
+	sw.Write([]byte("##anvil:sta"))
+	sw.Write([]byte("tus chunked message\n"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if captured != "chunked message" {
+		t.Errorf("expected status 'chunked message', got %q", captured)
+	}
+}
+
+func TestStatusWriter_FlushPartialLine(t *testing.T) {
+	var downstream bytes.Buffer
+	var mu sync.Mutex
+	var captured string
+
+	sw := newStatusWriter(&downstream, func(status string) {
+		mu.Lock()
+		captured = status
+		mu.Unlock()
+	})
+
+	// Write without trailing newline, then flush
+	sw.Write([]byte("##anvil:status final status"))
+	sw.Flush()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if captured != "final status" {
+		t.Errorf("expected status 'final status', got %q", captured)
+	}
+}
+
+func TestStatusWriter_EmptyStatusIgnored(t *testing.T) {
+	var downstream bytes.Buffer
+	callCount := 0
+
+	sw := newStatusWriter(&downstream, func(status string) {
+		callCount++
+	})
+
+	sw.Write([]byte("##anvil:status \n"))
+
+	if callCount != 0 {
+		t.Errorf("expected 0 callbacks for empty status, got %d", callCount)
 	}
 }


### PR DESCRIPTION
## Summary

- The `statusWriter` was only wrapping `cmd.Stdout`, so `##anvil:status` lines written to stderr were never detected
- Many runners (including Claude CLI) output progress and streaming data to stderr, causing status updates to be silently ignored in the daemon tick heartbeat
- Now both stdout and stderr are wrapped with `statusWriter`, with proper `Flush()` on both after process exit
- Adds 5 comprehensive `statusWriter` unit tests covering: basic detection, multiple updates, chunked/partial lines, flush behavior, and empty status filtering

Closes #135

## Test plan

- [ ] Create task that prints `##anvil:status test message` to stdout — verify tick shows "test message"
- [ ] Create task that prints `##anvil:status test message` to stderr — verify tick shows "test message"
- [ ] Verify status lines are stripped from downstream output (log files)
- [ ] Verify non-status lines still pass through to logs
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)