### PR TITLE
fix: daemon detection broken — CLI reports 'not running' while daemon is active

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -482,11 +482,9 @@ func runDaemonChild() {
 		log.Fatalf("failed to create ~/.anvil: %v", err)
 	}
 
-	pid := os.Getpid()
-	if err := os.WriteFile(config.PidFile(), []byte(strconv.Itoa(pid)), 0644); err != nil {
-		log.Fatalf("failed to write PID file: %v", err)
-	}
-	defer os.Remove(config.PidFile())
+	// PID file is written by daemon.Run() via checkAndWritePID().
+	// Do NOT write it here — that causes Run() to detect our own PID
+	// as an already-running daemon and exit without starting the socket server.
 
 	cfg, err := config.Load()
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Root cause**: `runDaemonChild()` wrote the PID file *before* calling `daemon.Run()`. When `Run()` then called `checkAndWritePID()`, it found the PID file containing our own PID, sent signal 0 to verify the process was alive (it was — ourselves), and returned `ErrDaemonAlreadyRunning`. This caused `Run()` to exit early without starting the Unix socket server.
- **Fix**: Removed the duplicate PID write from `runDaemonChild()`. The PID file is now written solely by `daemon.Run()` via `checkAndWritePID()`, which is the canonical path that also handles stale PID cleanup.
- **Impact**: All CLI commands (`ps`, `stop-on-idle`, `watch --stop`, `kill`, etc.) now correctly communicate with the daemon via the IPC socket.

## Test plan
- [ ] `anvil watch -d` starts daemon and writes PID file
- [ ] `anvil ps` shows running tasks (not "daemon not running")
- [ ] `anvil stop-on-idle` successfully signals daemon to drain
- [ ] `anvil watch --stop` successfully stops the daemon
- [ ] PID file is cleaned up on daemon exit
- [ ] Socket file is cleaned up on daemon exit
- [ ] Starting a second daemon correctly reports "already running"

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)