### PR TITLE
feat: live task dashboard for anvil ps --watch

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -1027,72 +1027,117 @@ func psWatch(jsonOutput bool) {
 		first = false
 
 		if jsonOutput {
-			// In JSON watch mode, output one JSON array per cycle
-			if !daemon.IsDaemonRunning() {
-				fmt.Println("[]")
-				continue
-			}
-			tasks, err := daemon.SendPsRequest()
-			if err != nil {
-				fmt.Println("[]")
-				continue
-			}
-			if len(tasks) == 0 {
-				fmt.Println("[]")
-				continue
-			}
-			data, err := json.MarshalIndent(tasks, "", "  ")
-			if err != nil {
-				fmt.Println("[]")
-				continue
-			}
-			fmt.Println(string(data))
+			psWatchJSON()
 			continue
 		}
 
-		// Text mode: clear screen and redraw
+		// Text mode: clear screen and redraw dashboard
 		fmt.Print("\033[2J\033[H") // ANSI: clear screen and move cursor to top-left
 
-		now := time.Now().Format("15:04:05")
-		fmt.Printf("Every 2s: anvil ps --watch                                  %s\n\n", now)
-
 		if !daemon.IsDaemonRunning() {
-			fmt.Println("daemon not running")
+			fmt.Println("anvil daemon — not running")
 			continue
 		}
 
-		if status, err := daemon.SendStatusRequest(); err == nil && status.Draining {
-			fmt.Println("(draining — no new tasks will be dispatched)")
-		}
+		status, statusErr := daemon.SendStatusRequest()
+		tasks, _ := daemon.SendPsRequest()
 
-		tasks, err := daemon.SendPsRequest()
-		if err != nil {
-			fmt.Printf("failed to get tasks: %v\n", err)
-			continue
-		}
-
-		if len(tasks) == 0 {
-			fmt.Println("no running tasks")
-			continue
-		}
-
-		fmt.Printf("%-30s %-20s %-10s %-10s %-30s %s\n", "PROJECT", "TASK", "PID", "ELAPSED", "STATUS", "STARTED")
-		fmt.Printf("%s\n", strings.Repeat("-", 120))
-
-		for _, t := range tasks {
-			status := ""
-			if t.Status != "" {
-				status = t.Status
+		// Header line
+		if statusErr == nil {
+			fmt.Printf("anvil daemon (PID %d), %d workers — Uptime: %s\n",
+				status.PID, status.Workers, status.Uptime)
+			fmt.Printf("Completed: %d | Failed: %d", status.Completed, status.Failed)
+			if status.Draining {
+				fmt.Print(" | DRAINING")
 			}
-			fmt.Printf("%-30s %-20s %-10d %-10s %-30s %s\n",
-				truncate(t.Project, 30),
-				truncate(t.Name, 20),
-				t.PID,
-				t.Elapsed,
-				truncate(status, 30),
-				t.Started)
+			fmt.Println()
+		} else {
+			fmt.Println("anvil daemon")
 		}
+		fmt.Println()
+
+		// Running tasks section
+		if len(tasks) > 0 {
+			fmt.Printf("RUNNING (%d)\n", len(tasks))
+			for _, t := range tasks {
+				statusText := t.Status
+				if statusText == "" {
+					statusText = "running"
+				}
+				// Build progress bar from percent_used
+				bar := progressBar(t.PercentUsed, 10)
+				projName := filepath.Base(t.Project)
+				fmt.Printf("  %-30s %-8s %s  %s\n",
+					truncate(projName+"/"+t.Name, 30),
+					t.Elapsed,
+					bar,
+					truncate(statusText, 40))
+			}
+		} else {
+			fmt.Println("RUNNING (0)")
+			fmt.Println("  (no tasks running)")
+		}
+
+		// Idle workers
+		if statusErr == nil {
+			idle := status.Workers - len(tasks)
+			if idle < 0 {
+				idle = 0
+			}
+			if idle > 0 {
+				fmt.Printf("\nIDLE (%d)\n", idle)
+				var ids []string
+				workerIdx := 0
+				for i := 0; i < status.Workers; i++ {
+					// Simple display: show idle worker indices
+					isRunning := false
+					if workerIdx < len(tasks) {
+						// Approximate: first N workers are busy
+						isRunning = i < len(tasks)
+					}
+					_ = workerIdx
+					if !isRunning {
+						ids = append(ids, fmt.Sprintf("[w%d]", i))
+					}
+				}
+				fmt.Printf("  %s\n", strings.Join(ids, " "))
+			}
+		}
+		fmt.Println()
 	}
+}
+
+func psWatchJSON() {
+	if !daemon.IsDaemonRunning() {
+		fmt.Println("[]")
+		return
+	}
+	tasks, err := daemon.SendPsRequest()
+	if err != nil || len(tasks) == 0 {
+		fmt.Println("[]")
+		return
+	}
+	data, err := json.MarshalIndent(tasks, "", "  ")
+	if err != nil {
+		fmt.Println("[]")
+		return
+	}
+	fmt.Println(string(data))
+}
+
+// progressBar returns a visual bar like "████░░░░░░" for the given percentage.
+func progressBar(percent float64, width int) string {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	filled := int(percent / 100 * float64(width))
+	if filled > width {
+		filled = width
+	}
+	return strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
 }
 
 // truncate shortens a string to the specified length

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -134,6 +134,10 @@ type Daemon struct {
 	// persistent task during this daemon lifetime.  Resets on daemon restart.
 	persistentBudgetUsed   map[string]time.Duration
 	persistentBudgetUsedMu sync.Mutex
+	// Dashboard counters
+	startedAt      time.Time
+	completedCount int64 // atomic
+	failedCount    int64 // atomic
 }
 
 type RunningTask struct {
@@ -205,6 +209,7 @@ func New(cfg *config.Config) *Daemon {
 
 func (d *Daemon) Run() {
 	defer close(d.done)
+	d.startedAt = time.Now()
 
 	// Write PID file on startup
 	if err := checkAndWritePID(); err != nil {
@@ -679,6 +684,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 	if forceCycled {
 		// Force-cycle is a normal lifecycle event, not a failure.
 		// Log it clearly and skip failure backoff/runner cooldown.
+		atomic.AddInt64(&d.completedCount, 1)
 		dlog.Info("persistent task %s force-cycled after %v — will restart on next tick", t.Name, elapsed.Round(time.Second))
 		// Clear failure count since force-cycle is not a real failure
 		d.persistentFailuresMu.Lock()
@@ -688,6 +694,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 		runRecord.Success = true
 		runRecord.Error = ""
 	} else if err != nil {
+		atomic.AddInt64(&d.failedCount, 1)
 		dlog.WorkerFail(workerID, projName, t.Name, err)
 		// If the runner failed, set a 5-minute cooldown to avoid retrying it immediately
 		if usedRunnerIdx >= 0 {
@@ -721,6 +728,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 			dlog.Info("persistent task %s failed (attempt %d) — backing off for %v", t.Name, failCount, backoffDuration)
 		}
 	} else {
+		atomic.AddInt64(&d.completedCount, 1)
 		dlog.WorkerDone(workerID, projName, t.Name, elapsed)
 		// Run on_success hook if defined
 		if t.OnSuccess != "" {
@@ -1094,7 +1102,14 @@ func (d *Daemon) handleKill(w http.ResponseWriter, r *http.Request) {
 
 // DaemonStatus holds runtime state about the daemon.
 type DaemonStatus struct {
-	Draining bool `json:"draining"`
+	Draining   bool   `json:"draining"`
+	PID        int    `json:"pid"`
+	Uptime     string `json:"uptime"`
+	StartedAt  string `json:"started_at"`
+	Workers    int    `json:"workers"`
+	Running    int    `json:"running"`
+	Completed  int64  `json:"completed"`
+	Failed     int64  `json:"failed"`
 }
 
 func (d *Daemon) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -1102,8 +1117,19 @@ func (d *Daemon) handleStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	d.tasksMu.RLock()
+	running := len(d.tasks)
+	d.tasksMu.RUnlock()
+
 	status := DaemonStatus{
-		Draining: atomic.LoadInt32(&d.draining) == 1,
+		Draining:  atomic.LoadInt32(&d.draining) == 1,
+		PID:       os.Getpid(),
+		Uptime:    time.Since(d.startedAt).Round(time.Second).String(),
+		StartedAt: d.startedAt.Format(time.RFC3339),
+		Workers:   d.config.MaxWorkers,
+		Running:   running,
+		Completed: atomic.LoadInt64(&d.completedCount),
+		Failed:    atomic.LoadInt64(&d.failedCount),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(status)


### PR DESCRIPTION
## Summary
- Enhances `anvil ps --watch` with a rich live dashboard replacing the plain table
- Dashboard shows daemon header (PID, workers, uptime), completed/failed counters, running tasks with progress bars, and idle worker indicators
- Enriched `/status` IPC endpoint with PID, uptime, worker count, running count, completed/failed counters
- Completed/failed counts tracked atomically in daemon for thread safety
- JSON watch mode preserved unchanged

### Example output
```
anvil daemon (PID 62173), 10 workers — Uptime: 2h34m0s
Completed: 142 | Failed: 3

RUNNING (4)
  delta/fix-pr-9060.md         9m35s    ████████░░  analyzing issues...
  delta/review-open-prs.md     45s      ██░░░░░░░░  running
  chain/backend-tasks.md       21s      █░░░░░░░░░  writing files
  primer/review-prs.md         30s      █░░░░░░░░░  running

IDLE (6)
  [w4] [w5] [w6] [w7] [w8] [w9]
```

## Test plan
- [ ] `anvil ps --watch` shows rich dashboard with header, running tasks, idle workers
- [ ] Progress bars reflect timeout percentage
- [ ] Completed/failed counters increment correctly
- [ ] Draining state is shown when active
- [ ] `Ctrl+C` exits cleanly
- [ ] `anvil ps --watch --json` still outputs JSON arrays
- [ ] `anvil status --json` now includes enriched fields (pid, uptime, workers, etc.)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)