### PR TITLE
Fix #182: Add webhook notifications for task lifecycle events

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,11 +18,21 @@ type Config struct {
 	Timeout      time.Duration  `yaml:"timeout"`
 	MaxWorkers   int            `yaml:"max_workers"`
 	MaxTodos     int            `yaml:"max_todos"` // deprecated: use max_workers
-	Hooks           HooksConfig     `yaml:"hooks"`
-	Retention       RetentionConfig `yaml:"retention"`
+	Hooks           HooksConfig        `yaml:"hooks"`
+	Retention       RetentionConfig    `yaml:"retention"`
+	Webhooks        map[string]WebhookConfig `yaml:"webhooks"`
 	InputTokenRate  float64         `yaml:"input_token_rate"`  // cost per 1M input tokens in USD (default: 3.0)
 	OutputTokenRate float64         `yaml:"output_token_rate"` // cost per 1M output tokens in USD (default: 15.0)
 	AutoUpdate      bool            `yaml:"auto_update"`       // opt-in: auto-update binary on daemon startup
+}
+
+// WebhookConfig defines a single webhook endpoint that receives task lifecycle events.
+type WebhookConfig struct {
+	URL     string            `yaml:"url"`
+	Method  string            `yaml:"method"`  // default: POST
+	Headers map[string]string `yaml:"headers"`
+	Events  []string          `yaml:"events"`  // e.g. ["success", "failure", "start", "timeout"]
+	Timeout time.Duration     `yaml:"timeout"` // default: 10s
 }
 
 // RetentionConfig defines data retention policies for logs and runs.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/johnjansen/anvil/internal/project"
 	"github.com/johnjansen/anvil/internal/runner"
 	"github.com/johnjansen/anvil/internal/updater"
+	"github.com/johnjansen/anvil/internal/webhook"
 
 	"gopkg.in/yaml.v3"
 )
@@ -135,6 +136,7 @@ type Daemon struct {
 	// persistent task during this daemon lifetime.  Resets on daemon restart.
 	persistentBudgetUsed   map[string]time.Duration
 	persistentBudgetUsedMu sync.Mutex
+	webhooks *webhook.Sender
 }
 
 type RunningTask struct {
@@ -201,6 +203,7 @@ func New(cfg *config.Config) *Daemon {
 		pendingTasks:  make(map[string]string),
 		stoppedTasks:         make(map[string]bool),
 		persistentBudgetUsed: make(map[string]time.Duration),
+		webhooks:             webhook.New(cfg.Webhooks),
 	}
 }
 
@@ -356,6 +359,15 @@ func (d *Daemon) reloadConfig() {
 		oldVal := d.config.TickInterval
 		d.config.TickInterval = newConfig.TickInterval
 		changes = append(changes, fmt.Sprintf("tick_interval %v->%v", oldVal, newConfig.TickInterval))
+	}
+
+	// webhooks: update sender config
+	d.config.Webhooks = newConfig.Webhooks
+	if d.webhooks != nil {
+		d.webhooks.UpdateConfig(newConfig.Webhooks)
+	} else if len(newConfig.Webhooks) > 0 {
+		d.webhooks = webhook.New(newConfig.Webhooks)
+		changes = append(changes, "webhooks configured")
 	}
 
 	if len(changes) > 0 {
@@ -568,6 +580,11 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 				task.SessionID = sid
 			}
 			d.tasksMu.Unlock()
+			// Fire task_start webhook
+			d.webhooks.Fire(webhook.EventStart, webhook.BuildPayload(t.Name, proj.Path, runID, startTime, time.Time{}, 0, ""))
+			if t.Webhook != "" {
+				d.webhooks.FireURL(t.Webhook, webhook.EventStart, webhook.BuildPayload(t.Name, proj.Path, runID, startTime, time.Time{}, 0, ""))
+			}
 		}, func(status string) {
 			d.tasksMu.Lock()
 			if task, ok := d.tasks[taskKey]; ok {
@@ -680,6 +697,7 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 	elapsed := time.Since(startTime)
 	// Detect force-cycle: persistent task hit its max runtime (context deadline exceeded)
 	forceCycled := t.IsPersistent() && err != nil && ctx.Err() == context.DeadlineExceeded
+	whPayload := webhook.BuildPayload(t.Name, proj.Path, runID, startTime, runRecord.Finished, runRecord.EstimatedCostUSD, runRecord.Error)
 	if forceCycled {
 		// Force-cycle is a normal lifecycle event, not a failure.
 		// Log it clearly and skip failure backoff/runner cooldown.
@@ -691,6 +709,10 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 		// Mark success in run record since this is expected behavior
 		runRecord.Success = true
 		runRecord.Error = ""
+		d.webhooks.Fire(webhook.EventPersistentCycle, whPayload)
+		if t.Webhook != "" {
+			d.webhooks.FireURL(t.Webhook, webhook.EventPersistentCycle, whPayload)
+		}
 	} else if err != nil {
 		dlog.WorkerFail(workerID, projName, t.Name, err)
 		// If the runner failed, set a 5-minute cooldown to avoid retrying it immediately
@@ -703,6 +725,15 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 		// Run on_failure hook if defined
 		if t.OnFailure != "" {
 			d.runHook("on_failure", t.OnFailure, proj.Path, t, logPath, usedSessionID, startTime, elapsed)
+		}
+		// Fire failure webhook (use timeout event if deadline exceeded)
+		whEvent := webhook.EventFailure
+		if ctx.Err() == context.DeadlineExceeded {
+			whEvent = webhook.EventTimeout
+		}
+		d.webhooks.Fire(whEvent, whPayload)
+		if t.Webhook != "" {
+			d.webhooks.FireURL(t.Webhook, whEvent, whPayload)
 		}
 		// For persistent tasks, track failures and apply exponential backoff
 		if t.IsPersistent() {
@@ -729,6 +760,10 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 		// Run on_success hook if defined
 		if t.OnSuccess != "" {
 			d.runHook("on_success", t.OnSuccess, proj.Path, t, logPath, usedSessionID, startTime, elapsed)
+		}
+		d.webhooks.Fire(webhook.EventSuccess, whPayload)
+		if t.Webhook != "" {
+			d.webhooks.FireURL(t.Webhook, webhook.EventSuccess, whPayload)
 		}
 		// Remove the todo file after successful execution (one-shot only)
 		if t.Schedule == "" {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -96,6 +96,7 @@ type Todo struct {
 	PersistentBudget     time.Duration // cumulative wall-clock budget per daemon lifetime (0 = unlimited)
 	MaxLogSize           int64         // max log file size in bytes (0 = use global default)
 	Runner               string        // per-task runner command override (empty = use global runner chain)
+	Webhook              string        // per-task webhook URL override (empty = use global webhooks only)
 }
 
 // RunRecord persists metadata for a single task dispatch, written after completion.
@@ -188,6 +189,7 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 			var persistentBudget time.Duration
 			var maxLogSize int64
 			runnerOverride := ""
+			webhookURL := ""
 			body := contentStr
 
 			// Track which frontmatter keys were explicitly set so project defaults
@@ -219,6 +221,7 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 						PersistentBudget     string   `yaml:"persistent_budget"`
 						MaxLogSize           string   `yaml:"max_log_size"`
 						Runner               string   `yaml:"runner"`
+						Webhook              string   `yaml:"webhook"`
 					}
 					if err := yaml.Unmarshal([]byte(fm), &fmData); err == nil {
 						// Parse raw keys to detect which fields were explicitly set.
@@ -254,6 +257,7 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 							maxLogSize, _ = config.ParseByteSize(fmData.MaxLogSize)
 						}
 						runnerOverride = fmData.Runner
+						webhookURL = fmData.Webhook
 					}
 				}
 			}
@@ -287,6 +291,7 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 				PersistentBudget:     persistentBudget,
 				MaxLogSize:           maxLogSize,
 				Runner:               runnerOverride,
+				Webhook:              webhookURL,
 			})
 		}
 	}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,210 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/johnjansen/anvil/internal/config"
+)
+
+// Event represents a task lifecycle event type.
+const (
+	EventStart          = "task_start"
+	EventSuccess        = "task_success"
+	EventFailure        = "task_failure"
+	EventTimeout        = "task_timeout"
+	EventPersistentCycle = "persistent_cycle"
+)
+
+// Payload is the JSON body sent to webhook endpoints.
+type Payload struct {
+	Event            string  `json:"event"`
+	TaskName         string  `json:"task_name"`
+	Project          string  `json:"project"`
+	Status           string  `json:"status"`
+	RunID            string  `json:"run_id,omitempty"`
+	StartedAt        string  `json:"started_at,omitempty"`
+	FinishedAt       string  `json:"finished_at,omitempty"`
+	DurationSeconds  float64 `json:"duration_seconds,omitempty"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd,omitempty"`
+	Error            string  `json:"error,omitempty"`
+}
+
+// Sender dispatches webhook notifications for task lifecycle events.
+type Sender struct {
+	webhooks map[string]config.WebhookConfig
+	client   *http.Client
+}
+
+// New creates a webhook Sender from config. Returns nil if no webhooks configured.
+func New(webhooks map[string]config.WebhookConfig) *Sender {
+	if len(webhooks) == 0 {
+		return nil
+	}
+	return &Sender{
+		webhooks: webhooks,
+		client:   &http.Client{},
+	}
+}
+
+// UpdateConfig replaces the webhook configuration (e.g. after config reload).
+func (s *Sender) UpdateConfig(webhooks map[string]config.WebhookConfig) {
+	s.webhooks = webhooks
+}
+
+// Fire sends the payload to all webhooks subscribed to the given event.
+// It runs asynchronously and never blocks the caller.
+func (s *Sender) Fire(event string, payload Payload) {
+	if s == nil {
+		return
+	}
+	payload.Event = event
+	payload.Status = eventToStatus(event)
+
+	for name, wh := range s.webhooks {
+		if !matchesEvent(wh.Events, event) {
+			continue
+		}
+		go s.deliver(name, wh, payload)
+	}
+}
+
+// FireURL sends the payload to a single URL (for per-task webhook overrides).
+func (s *Sender) FireURL(url, event string, payload Payload) {
+	if s == nil || url == "" {
+		return
+	}
+	payload.Event = event
+	payload.Status = eventToStatus(event)
+	wh := config.WebhookConfig{
+		URL:     url,
+		Method:  "POST",
+		Timeout: 10 * time.Second,
+	}
+	go s.deliver("task-override", wh, payload)
+}
+
+// deliver sends the webhook with retry (3 attempts, exponential backoff).
+func (s *Sender) deliver(name string, wh config.WebhookConfig, payload Payload) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("[webhook] %s: failed to marshal payload: %v", name, err)
+		return
+	}
+
+	method := wh.Method
+	if method == "" {
+		method = "POST"
+	}
+	timeout := wh.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	client := &http.Client{Timeout: timeout}
+
+	const maxAttempts = 3
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		req, err := http.NewRequest(method, wh.URL, bytes.NewReader(body))
+		if err != nil {
+			log.Printf("[webhook] %s: invalid request: %v", name, err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range wh.Headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("[webhook] %s: attempt %d/%d failed: %v", name, attempt, maxAttempts, err)
+			if attempt < maxAttempts {
+				time.Sleep(time.Duration(attempt) * 2 * time.Second)
+			}
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return // success
+		}
+		log.Printf("[webhook] %s: attempt %d/%d got status %d", name, attempt, maxAttempts, resp.StatusCode)
+		if attempt < maxAttempts {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+	}
+	log.Printf("[webhook] %s: all %d attempts failed for %s", name, maxAttempts, wh.URL)
+}
+
+// matchesEvent checks if the webhook's event filter includes the given event.
+// An empty events list means "all events".
+func matchesEvent(events []string, event string) bool {
+	if len(events) == 0 {
+		return true
+	}
+	short := eventToShort(event)
+	for _, e := range events {
+		if e == event || e == short {
+			return true
+		}
+	}
+	return false
+}
+
+// eventToStatus maps event names to status strings.
+func eventToStatus(event string) string {
+	switch event {
+	case EventSuccess:
+		return "success"
+	case EventFailure:
+		return "failure"
+	case EventStart:
+		return "started"
+	case EventTimeout:
+		return "timeout"
+	case EventPersistentCycle:
+		return "force_cycled"
+	default:
+		return event
+	}
+}
+
+// eventToShort maps full event names to short config names.
+func eventToShort(event string) string {
+	switch event {
+	case EventSuccess:
+		return "success"
+	case EventFailure:
+		return "failure"
+	case EventStart:
+		return "start"
+	case EventTimeout:
+		return "timeout"
+	case EventPersistentCycle:
+		return "persistent_cycle"
+	default:
+		return event
+	}
+}
+
+// BuildPayload constructs a webhook payload from task execution data.
+func BuildPayload(taskName, projectPath, runID string, startedAt, finishedAt time.Time, costUSD float64, errMsg string) Payload {
+	p := Payload{
+		TaskName:  taskName,
+		Project:   projectPath,
+		RunID:     runID,
+		StartedAt: startedAt.Format(time.RFC3339),
+	}
+	if !finishedAt.IsZero() {
+		p.FinishedAt = finishedAt.Format(time.RFC3339)
+		p.DurationSeconds = finishedAt.Sub(startedAt).Seconds()
+	}
+	p.EstimatedCostUSD = costUSD
+	if errMsg != "" {
+		p.Error = errMsg
+	}
+	return p
+}


### PR DESCRIPTION
## Summary
- Adds HTTP webhook notification system for task lifecycle events
- Global webhooks configured in `~/.anvil/config.yaml` with URL, method, headers, event filtering, and timeout
- Per-task webhook override via `webhook: <url>` frontmatter field
- Fires on: `task_start`, `task_success`, `task_failure`, `task_timeout`, `persistent_cycle`
- Non-blocking async delivery with 3 retries and exponential backoff
- Config hot-reload support via SIGHUP

## Webhook payload
```json
{
  "event": "task_success",
  "task_name": "check-issues.md",
  "project": "/Users/john/project",
  "status": "success",
  "run_id": "abc123",
  "started_at": "2026-02-26T10:00:00Z",
  "finished_at": "2026-02-26T10:05:00Z",
  "duration_seconds": 300,
  "estimated_cost_usd": 0.02
}
```

## Config example
```yaml
webhooks:
  slack_alert:
    url: "https://hooks.slack.com/..."
    events: ["failure", "timeout"]
    headers:
      Authorization: "Bearer token"
    timeout: 10s
```

## Test plan
- [ ] Configure a webhook in `~/.anvil/config.yaml` and verify it fires on task success/failure
- [ ] Test per-task webhook override via `webhook: <url>` frontmatter
- [ ] Verify webhooks are non-blocking (task completes regardless of webhook status)
- [ ] Test event filtering (e.g., only `failure` events fire)
- [ ] Verify failed webhook deliveries are logged but don't affect task outcome
- [ ] Test config hot-reload picks up new webhook configuration
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)