### PR TITLE
Fix #199: Serialize daemon log output to prevent interleaved lines

### DIFF
--- a/internal/daemon/logger.go
+++ b/internal/daemon/logger.go
@@ -132,11 +132,13 @@ func (l *daemonLogger) ts() string {
 }
 
 func (l *daemonLogger) println(line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Serialize stdout writes to prevent interleaved output from concurrent workers.
 	fmt.Fprintln(os.Stdout, line)
 
 	// Write a plain (no ANSI) copy to the log file.
-	l.mu.Lock()
-	defer l.mu.Unlock()
 	if l.logFile != nil {
 		plain := ansiPattern.ReplaceAllString(line, "") + "\n"
 		n, _ := l.logFile.WriteString(plain)


### PR DESCRIPTION
## Summary
- Move `fmt.Fprintln(os.Stdout, line)` inside the existing mutex in `daemonLogger.println()` so concurrent worker goroutines cannot interleave their log output on the terminal
- Root cause: the mutex only protected the log file write, not stdout — when multiple workers started simultaneously, their `fmt.Fprintln` calls would race and produce diagonal/staggered output
- The fix is a 2-line change: move the stdout write below `l.mu.Lock()`

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build` — builds cleanly
- [ ] Manual: start daemon with multiple tasks scheduled at the same time and verify log lines no longer interleave

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)