### PR TITLE
Fix #214: Add graceful shutdown with task completion guarantee

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -126,7 +126,7 @@ Commands:
   watch --install          Install as system service (auto-start on boot)
   watch --uninstall        Remove the system service
   watch --status           Show system service status
-  watch --stop             Stop the background daemon
+  watch --stop [--graceful] Stop the daemon (--graceful waits for tasks, --force kills)
   add [options] <task>     Add a task to the current project
   logs [<name>]            Raw worker output (all tasks if no name given)
   ps [--json] [-w|--watch] Show running tasks (--watch for live dashboard)
@@ -361,8 +361,11 @@ func watchCmd2(args []string) {
 	install := false
 	uninstall := false
 	status := false
-	for _, arg := range args {
-		switch arg {
+	graceful := false
+	force := false
+	gracefulTimeout := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
 		case "--daemonize", "-d":
 			daemonize = true
 		case "--stop":
@@ -375,6 +378,22 @@ func watchCmd2(args []string) {
 			uninstall = true
 		case "--status":
 			status = true
+		case "--graceful", "-g":
+			graceful = true
+		case "--force":
+			force = true
+		case "--timeout":
+			if i+1 < len(args) {
+				i++
+				gracefulTimeout = args[i]
+			}
+		default:
+			if strings.HasPrefix(args[i], "--graceful=") {
+				graceful = true
+				gracefulTimeout = strings.TrimPrefix(args[i], "--graceful=")
+			} else if strings.HasPrefix(args[i], "--timeout=") {
+				gracefulTimeout = strings.TrimPrefix(args[i], "--timeout=")
+			}
 		}
 	}
 
@@ -394,7 +413,11 @@ func watchCmd2(args []string) {
 	}
 
 	if stop {
-		stopDaemon()
+		if graceful {
+			stopDaemonGraceful(gracefulTimeout)
+		} else {
+			stopDaemon(force)
+		}
 		return
 	}
 
@@ -602,7 +625,7 @@ func runDaemonChild() {
 }
 
 // stopDaemon sends SIGTERM to the running daemon and waits for it to exit.
-func stopDaemon() {
+func stopDaemon(force bool) {
 	pid := readDaemonPID()
 	if pid == 0 {
 		fmt.Fprintln(os.Stderr, "no daemon running")
@@ -615,8 +638,19 @@ func stopDaemon() {
 		return
 	}
 
-	if err := proc.Signal(syscall.SIGTERM); err != nil {
+	sig := syscall.SIGTERM
+	if force {
+		sig = syscall.SIGKILL
+	}
+
+	if err := proc.Signal(sig); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to stop daemon: %v\n", err)
+		return
+	}
+
+	if force {
+		fmt.Fprintf(os.Stderr, "daemon force-killed (PID %d)\n", pid)
+		os.Remove(config.PidFile())
 		return
 	}
 
@@ -629,6 +663,86 @@ func stopDaemon() {
 		}
 	}
 	fmt.Fprintf(os.Stderr, "daemon did not stop in time (PID %d)\n", pid)
+}
+
+func stopDaemonGraceful(timeoutStr string) {
+	pid := readDaemonPID()
+	if pid == 0 {
+		fmt.Fprintln(os.Stderr, "no daemon running")
+		return
+	}
+
+	timeoutDur := 5 * time.Minute
+	if timeoutStr != "" {
+		d, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			log.Fatalf("invalid timeout: %s (use format like 5m, 30s, 1h)", timeoutStr)
+		}
+		timeoutDur = d
+	}
+
+	// Check running tasks before stopping
+	if daemon.IsDaemonRunning() {
+		tasks, err := daemon.SendPsRequest()
+		if err == nil && len(tasks) == 0 {
+			// No running tasks — stop immediately
+			stopDaemon(false)
+			return
+		}
+
+		if err == nil && len(tasks) > 0 {
+			fmt.Fprintf(os.Stderr, "Gracefully stopping daemon...\nWaiting for %d running task(s) to complete:\n", len(tasks))
+			for _, t := range tasks {
+				fmt.Fprintf(os.Stderr, "  - %s/%s (running %s)\n", t.Project, t.Name, t.Elapsed)
+			}
+			fmt.Fprintf(os.Stderr, "Press Ctrl+C to force stop\n\n")
+		}
+	}
+
+	// Send SIGTERM — daemon will do graceful shutdown internally
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "no daemon running")
+		return
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop daemon: %v\n", err)
+		return
+	}
+
+	// Poll until daemon stops or timeout expires
+	deadline := time.After(timeoutDur + 10*time.Second) // extra 10s buffer over daemon's own timeout
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	startTime := time.Now()
+
+	for {
+		select {
+		case <-deadline:
+			fmt.Fprintf(os.Stderr, "\nTimeout reached. Force-killing daemon (PID %d)...\n", pid)
+			proc.Signal(syscall.SIGKILL)
+			os.Remove(config.PidFile())
+			return
+		case <-ticker.C:
+			if _, err := os.Stat(config.PidFile()); os.IsNotExist(err) {
+				elapsed := time.Since(startTime).Round(time.Second)
+				fmt.Fprintf(os.Stderr, "\ndaemon stopped gracefully (PID %d, waited %s)\n", pid, elapsed)
+				return
+			}
+			// Show progress
+			if daemon.IsDaemonRunning() {
+				tasks, err := daemon.SendPsRequest()
+				if err == nil {
+					elapsed := time.Since(startTime).Round(time.Second)
+					remaining := timeoutDur - time.Since(startTime)
+					if remaining < 0 {
+						remaining = 0
+					}
+					fmt.Fprintf(os.Stderr, "\r  %d task(s) still running... (%s elapsed, %s remaining)  ", len(tasks), elapsed, remaining.Round(time.Second))
+				}
+			}
+		}
+	}
 }
 
 // watchCmd is the legacy "register a project" command, now superseded by

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,8 @@ type Config struct {
 	InputTokenRate  float64         `yaml:"input_token_rate"`  // cost per 1M input tokens in USD (default: 3.0)
 	OutputTokenRate float64         `yaml:"output_token_rate"` // cost per 1M output tokens in USD (default: 15.0)
 	AutoUpdate      bool            `yaml:"auto_update"`       // opt-in: auto-update binary on daemon startup
-	Env             map[string]string `yaml:"env"`             // global environment variables injected into all task executions
+	Env                      map[string]string `yaml:"env"`                        // global environment variables injected into all task executions
+	GracefulShutdownTimeout  time.Duration     `yaml:"graceful_shutdown_timeout"`   // max wait for running tasks on graceful stop (default: 5m)
 }
 
 // WebhookConfig defines a single webhook endpoint that receives task lifecycle events.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -106,6 +106,7 @@ type Daemon struct {
 	tasksMu     sync.RWMutex
 	httpServer  *http.Server
 	draining    int32           // atomic: 1 = stop-on-idle mode active
+	gracefulStop int32          // atomic: 1 = graceful shutdown in progress
 	drainedTasks map[string]bool // taskID -> true: per-task stop-on-idle
 	drainedMu   sync.Mutex
 	// persistentFailures tracks consecutive failure counts for persistent tasks
@@ -294,6 +295,11 @@ func (d *Daemon) Run() {
 		}(i)
 	}
 
+	// Set up SIGTERM/SIGINT handler for graceful shutdown
+	termChan := make(chan os.Signal, 1)
+	signal.Notify(termChan, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(termChan)
+
 	for {
 		select {
 		case <-d.stop:
@@ -303,6 +309,10 @@ func (d *Daemon) Run() {
 			}
 			close(d.workQueue) // signals workers to drain and exit
 			workerWg.Wait()
+			os.Remove(d.socketPath)
+			return
+		case <-termChan:
+			d.gracefulShutdown(&workerWg)
 			os.Remove(d.socketPath)
 			return
 		case <-sighupChan:
@@ -325,6 +335,62 @@ func (d *Daemon) Stop() {
 // Done returns a channel that is closed when the daemon has fully stopped.
 func (d *Daemon) Done() <-chan struct{} {
 	return d.done
+}
+
+// gracefulShutdown waits for running tasks to complete before stopping.
+// It sets the draining flag to prevent new task dispatches, then waits up to
+// the configured timeout for running tasks to finish.
+func (d *Daemon) gracefulShutdown(workerWg *sync.WaitGroup) {
+	atomic.StoreInt32(&d.gracefulStop, 1)
+	atomic.StoreInt32(&d.draining, 1) // prevent new task dispatches
+
+	timeout := d.config.GracefulShutdownTimeout
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+
+	d.tasksMu.RLock()
+	taskCount := len(d.tasks)
+	d.tasksMu.RUnlock()
+
+	if taskCount == 0 {
+		dlog.Info("graceful shutdown: no running tasks, stopping immediately")
+	} else {
+		dlog.Info("graceful shutdown: waiting for %d running task(s) to complete (timeout: %s)", taskCount, timeout)
+		deadline := time.After(timeout)
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+	waitLoop:
+		for {
+			select {
+			case <-deadline:
+				d.tasksMu.RLock()
+				remaining := len(d.tasks)
+				d.tasksMu.RUnlock()
+				dlog.Warn("graceful shutdown timeout reached, %d task(s) still running — force stopping", remaining)
+				break waitLoop
+			case <-ticker.C:
+				d.tasksMu.RLock()
+				remaining := len(d.tasks)
+				d.tasksMu.RUnlock()
+				if remaining == 0 {
+					dlog.Info("graceful shutdown: all tasks completed")
+					break waitLoop
+				}
+			}
+		}
+	}
+
+	dlog.Stopping()
+	if d.httpServer != nil {
+		d.httpServer.Shutdown(context.Background())
+	}
+	close(d.workQueue)
+	workerWg.Wait()
+	d.stopOnce.Do(func() {
+		close(d.stop)
+	})
 }
 
 // reloadConfig reads the config file and updates the daemon's configuration.


### PR DESCRIPTION
## Summary
- Adds `--graceful` flag to `anvil watch --stop` that waits for running tasks to complete before stopping the daemon (default timeout: 5m)
- Adds `--timeout` flag for configurable wait duration
- Adds `--force` flag for immediate kill (SIGKILL) as explicit alternative
- Shows real-time progress: running task count, elapsed time, remaining time
- Daemon-side SIGTERM handler now triggers graceful shutdown automatically — sets draining flag to prevent new dispatches, waits for running tasks
- Adds `graceful_shutdown_timeout` config option in `~/.anvil/config.yaml`

## Test plan
- [x] `go build ./cmd/anvil/` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `anvil watch --stop --graceful` shows progress for running tasks
- [ ] Manual test: verify tasks complete before daemon stops
- [ ] Manual test: `--timeout 10s` forces shutdown after timeout
- [ ] Manual test: `--force` immediately kills daemon
- [ ] Manual test: Ctrl+C during graceful wait falls through

🤖 Generated with [Claude Code](https://claude.com/claude-code)