### PR TITLE
Fix #243: Add task state management for long-running data processing

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -176,6 +176,7 @@ Task subcommands:
   wait <name> [--timeout D]  Block until a running task completes (exit 0=ok, 1=fail, 2=timeout)
   analyze [-a|--all]         Detect scheduling conflicts and overlapping tasks
   pipeline [--dot|--verbose] [--all]  Visualize task dependency pipelines
+  state <name> [--export|--import|--clear]  View or manage task state
   reset-budget <name>        Reset persistent task budget consumption
   export [names...] [-a] [-o file]  Export tasks to JSON for sharing or backup
   import <file> [options]   Import tasks from a JSON export file
@@ -1847,6 +1848,8 @@ func taskCmd(args []string) {
 		taskWaitCmd(args[1:])
 	case "analyze":
 		taskAnalyzeCmd(args[1:])
+	case "state":
+		taskStateCmd(args[1:])
 	case "reset-budget":
 		taskResetBudgetCmd(args[1:])
 	case "pipeline":
@@ -6056,6 +6059,119 @@ Options:
 
 	fmt.Printf("\n%d overlap(s) across %d time group(s). Consider staggering schedules or increasing max_workers.\n", totalConflicts, len(groupList))
 	os.Exit(1)
+}
+
+func taskStateCmd(args []string) {
+	exportPath := ""
+	importPath := ""
+	clear := false
+
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "--help":
+			fmt.Fprintf(os.Stderr, `usage: anvil task state <name> [--export file] [--import file] [--clear]
+
+View or manage structured task state.
+
+Options:
+  --export file    Export state to a JSON file
+  --import file    Import state from a JSON file
+  --clear          Clear the task's state
+`)
+			os.Exit(0)
+		case "--export":
+			if i+1 < len(args) {
+				i++
+				exportPath = args[i]
+			}
+		case "--import":
+			if i+1 < len(args) {
+				i++
+				importPath = args[i]
+			}
+		case "--clear":
+			clear = true
+		default:
+			positional = append(positional, args[i])
+		}
+	}
+
+	if len(positional) == 0 {
+		fmt.Fprintf(os.Stderr, "usage: anvil task state <name> [--export file] [--import file] [--clear]\n")
+		os.Exit(1)
+	}
+
+	taskName := positional[0]
+
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		log.Fatalf("bad path: %v", err)
+	}
+	proj, err := project.Load(abs)
+	if err != nil {
+		log.Fatalf("failed to load project: %v", err)
+	}
+	todos, err := proj.LoadTodos()
+	if err != nil {
+		log.Fatalf("failed to load todos: %v", err)
+	}
+
+	todo := findTodo(todos, taskName)
+	if todo == nil {
+		fmt.Fprintf(os.Stderr, "task not found: %s\n", taskName)
+		os.Exit(1)
+	}
+
+	bucket, key := project.ResolveStateBucketKey(*todo)
+	if bucket == "" {
+		fmt.Fprintf(os.Stderr, "task %s has no state_bucket configured\n", taskName)
+		fmt.Fprintf(os.Stderr, "Add 'state_bucket: <name>' to the task frontmatter to enable state management\n")
+		os.Exit(1)
+	}
+
+	if clear {
+		if err := project.ClearState(bucket, key); err != nil {
+			log.Fatalf("failed to clear state: %v", err)
+		}
+		fmt.Printf("state cleared for %s (bucket: %s, key: %s)\n", taskName, bucket, key)
+		return
+	}
+
+	if importPath != "" {
+		data, err := os.ReadFile(importPath)
+		if err != nil {
+			log.Fatalf("failed to read %s: %v", importPath, err)
+		}
+		if err := project.WriteState(bucket, key, string(data)); err != nil {
+			log.Fatalf("failed to write state: %v", err)
+		}
+		fmt.Printf("state imported from %s (bucket: %s, key: %s)\n", importPath, bucket, key)
+		return
+	}
+
+	// Read current state
+	data, err := project.ReadState(bucket, key)
+	if err != nil {
+		log.Fatalf("failed to read state: %v", err)
+	}
+
+	if data == "" {
+		fmt.Printf("no state for %s (bucket: %s, key: %s)\n", taskName, bucket, key)
+		return
+	}
+
+	if exportPath != "" {
+		if err := os.WriteFile(exportPath, []byte(data), 0644); err != nil {
+			log.Fatalf("failed to write %s: %v", exportPath, err)
+		}
+		fmt.Printf("state exported to %s\n", exportPath)
+		return
+	}
+
+	// Display state
+	fmt.Printf("State for %s (bucket: %s, key: %s):\n", taskName, bucket, key)
+	fmt.Println(data)
 }
 
 // formatDurationShort formats a duration as short human-readable relative time.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,8 +146,15 @@ func DaemonLogPath() string {
 	return filepath.Join(Dir(), "daemon.log")
 }
 
+func StateDir() string {
+	return filepath.Join(Dir(), "state")
+}
+
 func EnsureDir() error {
 	if err := os.MkdirAll(Dir(), 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(StateDir(), 0755); err != nil {
 		return err
 	}
 	return os.MkdirAll(WatchedDir(), 0755)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -718,6 +718,23 @@ func (d *Daemon) runTask(workerID int, proj *project.Project, t project.Todo) {
 			}
 		}
 
+		// If state bucket is configured, set up state file for the task
+		if bucket, key := project.ResolveStateBucketKey(t); bucket != "" {
+			if mergedEnv == nil {
+				mergedEnv = make(map[string]string)
+			}
+			stateFile := project.StatePath(bucket, key)
+			// Ensure the state directory exists
+			os.MkdirAll(filepath.Dir(stateFile), 0755)
+			// Create empty state file if it doesn't exist
+			if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+				os.WriteFile(stateFile, []byte("{}"), 0644)
+			}
+			mergedEnv["ANVIL_STATE_FILE"] = stateFile
+			mergedEnv["ANVIL_STATE_BUCKET"] = bucket
+			mergedEnv["ANVIL_STATE_KEY"] = key
+		}
+
 		usedSessionID, logPath, usedRunnerIdx, stderrOutput, err = d.runner.Run(ctx, proj.Path, sessionToResume, resume, t.SkipPermissions, t.AllowedTools, t.Content, taskLabel, logDir, skipIndices, mergedEnv, func(pid int, lp string, sid string) {
 			childPID = pid
 			d.tasksMu.Lock()

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -101,6 +101,8 @@ type Todo struct {
 	Env                  map[string]string // environment variables injected into task execution
 	DependsOn            []string      // list of task names this task depends on (all must succeed before running)
 	Checkpoint           bool          // if true, capture ##anvil:checkpoint output and inject on resume
+	StateBucket          string        // named state bucket for structured state persistence
+	StateKey             string        // key within bucket (default: task ID)
 }
 
 // RunRecord persists metadata for a single task dispatch, written after completion.
@@ -202,6 +204,8 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 			var envVars map[string]string
 			var dependsOn []string
 			checkpoint := false
+			stateBucket := ""
+			stateKey := ""
 			body := contentStr
 
 			// Track which frontmatter keys were explicitly set so project defaults
@@ -238,6 +242,8 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 						Env                  map[string]string `yaml:"env"`
 						DependsOn            []string          `yaml:"depends_on"`
 						Checkpoint           bool              `yaml:"checkpoint"`
+						StateBucket          string            `yaml:"state_bucket"`
+						StateKey             string            `yaml:"state_key"`
 					}
 					if err := yaml.Unmarshal([]byte(fm), &fmData); err == nil {
 						// Parse raw keys to detect which fields were explicitly set.
@@ -278,6 +284,8 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 						envVars = fmData.Env
 						dependsOn = fmData.DependsOn
 						checkpoint = fmData.Checkpoint
+						stateBucket = fmData.StateBucket
+						stateKey = fmData.StateKey
 					}
 				}
 			}
@@ -319,6 +327,8 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 				Env:                  resolvedEnv,
 				DependsOn:            dependsOn,
 				Checkpoint:           checkpoint,
+				StateBucket:          stateBucket,
+				StateKey:             stateKey,
 			})
 		}
 	}
@@ -824,4 +834,57 @@ func ListTemplates(projectPath string) ([]Template, error) {
 		}
 	}
 	return templates, nil
+}
+
+// StatePath returns the file path for a task's state file.
+// State is stored at ~/.anvil/state/<bucket>/<key>.json
+func StatePath(bucket, key string) string {
+	return filepath.Join(config.StateDir(), bucket, key+".json")
+}
+
+// ReadState reads the JSON state for a given bucket/key.
+// Returns empty string if no state exists.
+func ReadState(bucket, key string) (string, error) {
+	p := StatePath(bucket, key)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteState writes JSON state for a given bucket/key.
+func WriteState(bucket, key, data string) error {
+	p := StatePath(bucket, key)
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(data), 0644)
+}
+
+// ClearState removes the state file for a given bucket/key.
+func ClearState(bucket, key string) error {
+	p := StatePath(bucket, key)
+	err := os.Remove(p)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ResolveStateBucketKey returns the effective bucket and key for a task.
+// If bucket is empty, returns empty strings (no state configured).
+// If key is empty, defaults to the task ID.
+func ResolveStateBucketKey(t Todo) (string, string) {
+	if t.StateBucket == "" {
+		return "", ""
+	}
+	key := t.StateKey
+	if key == "" {
+		key = t.ID
+	}
+	return t.StateBucket, key
 }


### PR DESCRIPTION
## Summary
- Adds `state_bucket` and `state_key` frontmatter fields for declaring structured state per task
- State persisted as JSON in `~/.anvil/state/<bucket>/<key>.json`, survives daemon restarts
- Injects `ANVIL_STATE_FILE`, `ANVIL_STATE_BUCKET`, `ANVIL_STATE_KEY` env vars into task execution
- Tasks read/write state directly via the state file (any language can use it)
- Dependent tasks can share state via same bucket name
- Adds `anvil task state` CLI: view, `--export`, `--import`, `--clear`
- Adds `StateDir()` helper to config and ensures directory exists on startup

## Test plan
- [x] `go build ./cmd/anvil/` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `anvil task state --help` shows usage
- [x] `anvil task state <name>` shows helpful error when no state_bucket configured
- [ ] Manual test: add `state_bucket: test` to task, verify `ANVIL_STATE_FILE` is set during execution
- [ ] Manual test: write state in task, verify `anvil task state <name>` reads it back
- [ ] Manual test: `--export`/`--import`/`--clear` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)