### PR TITLE
Fix #244: Use speckit for planning anvil tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,4 +26,18 @@ Markdown (GitHub-Flavored Markdown compatible with dev.to, Medium, and static bl
 - 002-cli-ecosystem-blog-post: Added Markdown (GitHub-Flavored Markdown compatible with dev.to, Medium, and static blog platforms) + None (standalone markdown document)
 
 <!-- MANUAL ADDITIONS START -->
+
+## Development Workflow
+
+All features and non-trivial bug fixes MUST follow the speckit workflow:
+
+1. `/speckit.specify` — Create feature spec from issue description
+2. `/speckit.plan` — Generate technical implementation plan
+3. `/speckit.tasks` — Break plan into dependency-ordered tasks
+4. `/speckit.implement` — Execute tasks with validation
+
+Trivial fixes (1-2 line changes) may skip speckit and implement directly.
+
+The automated planning task in `.anvil/todos/` follows this same workflow when picking up GitHub issues.
+
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary
- Updates the automated planning task (in AnvilTasks) to use the speckit workflow instead of ad-hoc implementation
- New workflow: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks` → `/speckit.implement`
- Documents speckit workflow requirement in CLAUDE.md for all contributors
- Trivial bug fixes (1-2 line changes) may still skip speckit

## Changes
- **CLAUDE.md**: Added "Development Workflow" section documenting the speckit requirement
- **AnvilTasks** (external repo): Updated planning task to follow three-phase approach:
  - Phase 1: Issue selection (unchanged)
  - Phase 2: Speckit planning (specify → plan → tasks → implement)
  - Phase 3: Delivery (PR + label updates)

## Test plan
- [x] Go build and tests still pass (no Go code changes)
- [x] Task file validated for correct YAML frontmatter
- [x] AnvilTasks change committed and pushed
- [ ] Manual test: next automated run should use speckit workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)