### PR TITLE
fix: daemon output line breaks in raw terminal mode

### DIFF
--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -335,26 +335,31 @@ func serveCmd() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
+	// Enter raw terminal mode BEFORE starting the daemon so that all output
+	// uses \r\n from the very first line. Raw mode disables OPOST, which means
+	// bare \n no longer returns the cursor to column 0.
+	fd := int(os.Stdin.Fd())
+	oldTermState, termErr := term.MakeRaw(fd)
+	if termErr == nil {
+		origWriter := log.Writer()
+		log.SetOutput(&rawLineWriter{w: origWriter})
+		daemon.SetRawMode(true)
+		defer func() {
+			term.Restore(fd, oldTermState)
+			log.SetOutput(origWriter)
+			daemon.SetRawMode(false)
+		}()
+	}
+
 	go d.Run()
 
 	// Start hot-daemonize listener in background
 	detachCh := make(chan struct{})
 	go func() {
-		// Set stdin to raw mode to read single keypress
-		fd := int(os.Stdin.Fd())
-		oldState, err := term.MakeRaw(fd)
-		if err != nil {
+		if termErr != nil {
 			// Not a terminal, skip hot-daemonize
 			return
 		}
-		// Raw mode disables OPOST (\n → \r\n translation), so wrap
-		// log and stderr output to keep line breaks working.
-		origWriter := log.Writer()
-		log.SetOutput(&rawLineWriter{w: origWriter})
-		defer func() {
-			term.Restore(fd, oldState)
-			log.SetOutput(origWriter)
-		}()
 
 		buf := make([]byte, 1)
 		n, err := os.Stdin.Read(buf)

--- a/internal/daemon/logger.go
+++ b/internal/daemon/logger.go
@@ -37,7 +37,8 @@ var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 const maxLogSize = 1 << 20 // 1 MB
 
 type daemonLogger struct {
-	isTTY bool
+	isTTY   bool
+	rawMode bool // when true, println writes \r\n instead of \n for raw terminal mode
 
 	mu      sync.Mutex
 	logFile *os.File
@@ -131,12 +132,26 @@ func (l *daemonLogger) ts() string {
 	return time.Now().Format("15:04:05")
 }
 
+// SetRawMode toggles raw terminal mode output. When enabled, println writes
+// \r\n instead of bare \n so that lines start at column 0 when OPOST is disabled.
+func SetRawMode(enabled bool) {
+	dlog.mu.Lock()
+	dlog.rawMode = enabled
+	dlog.mu.Unlock()
+}
+
 func (l *daemonLogger) println(line string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	// Serialize stdout writes to prevent interleaved output from concurrent workers.
-	fmt.Fprintln(os.Stdout, line)
+	// In raw terminal mode, \n alone only moves the cursor down without returning
+	// to column 0, so we must write \r\n explicitly.
+	if l.rawMode {
+		fmt.Fprint(os.Stdout, line+"\r\n")
+	} else {
+		fmt.Fprintln(os.Stdout, line)
+	}
 
 	// Write a plain (no ANSI) copy to the log file.
 	if l.logFile != nil {


### PR DESCRIPTION
## Summary

- Fix horizontal drift in daemon log output when running in foreground (`anvil watch`) mode
- **Bug 1**: `dlog.println()` writes bare `\n` to stdout via `fmt.Fprintln`, bypassing the `rawLineWriter` wrapper that was only applied to `log.SetOutput()` — so ~95% of daemon output was unaffected by previous fix attempts
- **Bug 2**: `term.MakeRaw()` was called inside a goroutine that races with `go d.Run()` — the daemon starts logging before raw mode is even configured
- Add `rawMode` flag to `daemonLogger` and move raw mode setup to run synchronously before `d.Run()`

## Test plan

- [x] `anvil watch` in foreground — all log lines start at column 0 (verified)
- [x] `go test ./internal/...` passes
- [ ] `anvil watch -d` (daemonized) — daemon.log contains standard `\n`, no spurious `\r`

🤖 Generated with [Claude Code](https://claude.com/claude-code)