### PR TITLE
fix: preserve task files with frontmatter parse errors

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2062,6 +2062,11 @@ func (d *Daemon) tick(now time.Time) {
 			if t.Disabled {
 				continue
 			}
+			// Skip tasks with frontmatter parse errors (file is preserved on disk)
+			if t.ParseError != "" {
+				dlog.Warn("skip %s/%s — %s (fix the task file to resume)", projName, t.Name, t.ParseError)
+				continue
+			}
 			// Include task if:
 			// - one-shot (empty schedule)
 			// - cron schedule matches current minute

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -111,6 +111,7 @@ type Todo struct {
 	Checkpoint           bool          // if true, capture ##anvil:checkpoint output and inject on resume
 	Window               AllowedWindow // per-task execution time window (empty = no restriction)
 	ForceWindow          bool          // if true, bypass time window and quiet hours checks (set by force-run)
+	ParseError           string        // non-empty if frontmatter failed to parse; task is preserved but should not be executed
 }
 
 // RunRecord persists metadata for a single task dispatch, written after completion.
@@ -251,7 +252,20 @@ func (p *Project) LoadTodos() ([]Todo, error) {
 						Checkpoint           bool              `yaml:"checkpoint"`
 						AllowedWindow        *AllowedWindow    `yaml:"allowed_window"`
 					}
-					if err := yaml.Unmarshal([]byte(fm), &fmData); err == nil {
+					if err := yaml.Unmarshal([]byte(fm), &fmData); err != nil {
+						// Frontmatter has a parse error — preserve the task file but mark it
+						// as broken so the daemon skips execution and logs a warning.
+						fmt.Fprintf(os.Stderr, "anvil: warning: %s: frontmatter parse error: %v (task preserved but will not run)\n", fp, err)
+						todos = append(todos, Todo{
+							Path:       fp,
+							Name:       e.Name(),
+							Priority:   pri,
+							Content:    body,
+							IsLocked:   hasLock,
+							ParseError: fmt.Sprintf("frontmatter parse error: %v", err),
+						})
+						continue
+					} else {
 						// Parse raw keys to detect which fields were explicitly set.
 						_ = yaml.Unmarshal([]byte(fm), &fmKeys)
 


### PR DESCRIPTION
## Summary
- Fix silent task file deletion when YAML frontmatter has parse errors
- Tasks with invalid frontmatter are now preserved on disk with a ParseError field
- Daemon skips tasks with ParseError and logs a warning instead of executing/deleting them

## Root Cause
When `yaml.Unmarshal` failed on task frontmatter, the error was silently swallowed
(`if err == nil` guard) and the task was never added to the todo list. This made
the task invisible to the daemon, and in certain scenarios could lead to data loss.

## Changes
- **internal/project/project.go**: Added `ParseError` field to `Todo` struct. Changed
  frontmatter parsing to handle errors by preserving the task with `ParseError` set
  and logging a warning to stderr.
- **internal/daemon/daemon.go**: Added check to skip tasks with `ParseError` in the
  tick loop, with a warning log message.

## Test plan
- [ ] Create a task file with valid frontmatter, verify it runs normally
- [ ] Create a task file with invalid YAML frontmatter (e.g. `schedule: [invalid`)
- [ ] Verify the task file is preserved on disk (not deleted)
- [ ] Verify a warning is logged to stderr during LoadTodos
- [ ] Verify the daemon logs a skip warning for the broken task
- [ ] Fix the frontmatter and verify the task resumes normal execution

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)