### PR TITLE
Add task dry-run impact analysis before adding new tasks

### DIFF
--- a/cmd/anvil/impact.go
+++ b/cmd/anvil/impact.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/johnjansen/anvil/internal/cron"
+	"github.com/johnjansen/anvil/internal/project"
+)
+
+// Conflict represents a scheduling conflict between the proposed task and an existing task.
+type ImpactConflict struct {
+	TaskName    string    `json:"task"`
+	Schedule    string    `json:"schedule"`
+	OverlapTime time.Time `json:"overlap_time"`
+}
+
+// Suggestion represents an alternative schedule with fewer conflicts.
+type Suggestion struct {
+	Schedule      string `json:"schedule"`
+	ConflictCount int    `json:"conflicts"`
+	Description   string `json:"description"`
+}
+
+// ImpactReport is the result of analyzing a proposed schedule against existing tasks.
+type ImpactReport struct {
+	Schedule        string       `json:"schedule"`
+	IsValid         bool         `json:"valid"`
+	ParseError      string       `json:"parse_error,omitempty"`
+	NextRun         time.Time    `json:"next_run,omitempty"`
+	Conflicts       []ImpactConflict   `json:"conflicts"`
+	PeakConcurrency int          `json:"peak_concurrency"`
+	PeakTime        time.Time    `json:"peak_time,omitempty"`
+	Suggestions     []Suggestion `json:"suggestions,omitempty"`
+	NoSchedule      bool         `json:"no_schedule,omitempty"`
+}
+
+// computeConflicts checks a proposed schedule against all active tasks and returns conflicts.
+// This reuses the overlap detection algorithm from the original taskCreateCmd.
+func computeConflicts(schedule string, todos []project.Todo) []ImpactConflict {
+	newParser, err := cron.Parse(schedule)
+	if err != nil {
+		return nil
+	}
+	now := time.Now().Truncate(time.Minute)
+	var conflicts []ImpactConflict
+	for _, t := range todos {
+		if t.Schedule == "" || t.Schedule == "persistent" || t.Disabled {
+			continue
+		}
+		existParser, err := cron.Parse(t.Schedule)
+		if err != nil {
+			continue
+		}
+		cur := now
+		for k := 0; k < 30; k++ {
+			newNext, e1 := newParser.Next(cur)
+			existNext, e2 := existParser.Next(cur)
+			if e1 != nil || e2 != nil {
+				break
+			}
+			diff := newNext.Sub(existNext)
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff <= time.Minute {
+				conflicts = append(conflicts, ImpactConflict{
+					TaskName:    strings.TrimSuffix(t.Name, ".md"),
+					Schedule:    t.Schedule,
+					OverlapTime: newNext,
+				})
+				break
+			}
+			if newNext.Before(existNext) {
+				cur = newNext
+			} else {
+				cur = existNext
+			}
+		}
+	}
+	return conflicts
+}
+
+// computePeakConcurrency enumerates next-24h firing times for all active tasks plus the
+// proposed schedule, and finds the time slot with maximum concurrent tasks.
+func computePeakConcurrency(schedule string, todos []project.Todo) (int, time.Time) {
+	now := time.Now().Truncate(time.Minute)
+	end := now.Add(24 * time.Hour)
+
+	// Collect firing times per minute slot
+	slotCounts := make(map[time.Time]int)
+
+	// Add proposed schedule's firing times
+	if p, err := cron.Parse(schedule); err == nil {
+		cur := now
+		for {
+			next, err := p.Next(cur)
+			if err != nil || next.After(end) {
+				break
+			}
+			slotCounts[next.Truncate(time.Minute)]++
+			cur = next
+		}
+	}
+
+	// Add existing tasks' firing times
+	for _, t := range todos {
+		if t.Schedule == "" || t.Schedule == "persistent" || t.Disabled {
+			continue
+		}
+		p, err := cron.Parse(t.Schedule)
+		if err != nil {
+			continue
+		}
+		cur := now
+		for {
+			next, err := p.Next(cur)
+			if err != nil || next.After(end) {
+				break
+			}
+			slotCounts[next.Truncate(time.Minute)]++
+			cur = next
+		}
+	}
+
+	// Find peak
+	peak := 0
+	var peakTime time.Time
+	for t, count := range slotCounts {
+		if count > peak {
+			peak = count
+			peakTime = t
+		}
+	}
+	return peak, peakTime
+}
+
+// suggestAlternatives generates alternative schedules by shifting hours and checking conflicts.
+func suggestAlternatives(schedule string, todos []project.Todo, currentConflicts int) []Suggestion {
+	if currentConflicts == 0 {
+		return nil
+	}
+	fields := strings.Fields(schedule)
+	if len(fields) < 5 {
+		return nil
+	}
+
+	// Parse the hour field
+	var hour int
+	if _, err := fmt.Sscanf(fields[1], "%d", &hour); err != nil {
+		// Can't easily suggest alternatives for complex hour patterns
+		return nil
+	}
+
+	shifts := []struct {
+		offset int
+		desc   string
+	}{
+		{1, "Shift +1 hour"},
+		{-1, "Shift -1 hour"},
+		{2, "Shift +2 hours"},
+		{-2, "Shift -2 hours"},
+		{3, "Shift +3 hours"},
+		{-3, "Shift -3 hours"},
+	}
+
+	var suggestions []Suggestion
+	for _, s := range shifts {
+		newHour := (hour + s.offset + 24) % 24
+		newFields := make([]string, len(fields))
+		copy(newFields, fields)
+		newFields[1] = fmt.Sprintf("%d", newHour)
+		candidate := strings.Join(newFields, " ")
+
+		conflicts := computeConflicts(candidate, todos)
+		if len(conflicts) < currentConflicts {
+			suggestions = append(suggestions, Suggestion{
+				Schedule:      candidate,
+				ConflictCount: len(conflicts),
+				Description:   s.desc,
+			})
+		}
+		if len(suggestions) >= 3 {
+			break
+		}
+	}
+
+	// Also try shifting minutes by 30 if we haven't found 3 yet
+	if len(suggestions) < 3 {
+		var minute int
+		if _, err := fmt.Sscanf(fields[0], "%d", &minute); err == nil {
+			newMinute := (minute + 30) % 60
+			newFields := make([]string, len(fields))
+			copy(newFields, fields)
+			newFields[0] = fmt.Sprintf("%d", newMinute)
+			candidate := strings.Join(newFields, " ")
+			conflicts := computeConflicts(candidate, todos)
+			if len(conflicts) < currentConflicts {
+				suggestions = append(suggestions, Suggestion{
+					Schedule:      candidate,
+					ConflictCount: len(conflicts),
+					Description:   "Shift +30 minutes",
+				})
+			}
+		}
+	}
+
+	return suggestions
+}
+
+// analyzeImpact produces a full impact report for a proposed schedule against existing tasks.
+func analyzeImpact(schedule string, todos []project.Todo) ImpactReport {
+	report := ImpactReport{
+		Schedule:  schedule,
+		Conflicts: []ImpactConflict{}, // ensure non-nil for JSON
+	}
+
+	if schedule == "" {
+		report.NoSchedule = true
+		return report
+	}
+
+	p, err := cron.Parse(schedule)
+	if err != nil {
+		report.ParseError = err.Error()
+		return report
+	}
+	report.IsValid = true
+
+	if next, err := p.Next(time.Now()); err == nil {
+		report.NextRun = next
+	}
+
+	report.Conflicts = computeConflicts(schedule, todos)
+	if report.Conflicts == nil {
+		report.Conflicts = []ImpactConflict{}
+	}
+
+	report.PeakConcurrency, report.PeakTime = computePeakConcurrency(schedule, todos)
+
+	report.Suggestions = suggestAlternatives(schedule, todos, len(report.Conflicts))
+
+	return report
+}
+
+// printImpactReport displays the impact analysis in human-readable format.
+func printImpactReport(report ImpactReport) {
+	if report.NoSchedule {
+		fmt.Println("No schedule specified (one-shot task).")
+		return
+	}
+
+	if report.ParseError != "" {
+		log.Fatalf("invalid cron expression: %s (%s)", report.Schedule, report.ParseError)
+	}
+
+	fmt.Println()
+	fmt.Println("Impact Analysis")
+	fmt.Println(strings.Repeat("\u2500", 40))
+	fmt.Printf("Schedule:   %s\n", report.Schedule)
+	if !report.NextRun.IsZero() {
+		until := time.Until(report.NextRun).Round(time.Minute)
+		fmt.Printf("Next Run:   %s (%s from now)\n", report.NextRun.Format("Mon Jan 2 15:04:05"), until)
+	}
+	fmt.Println()
+
+	if len(report.Conflicts) == 0 {
+		fmt.Println("No scheduling conflicts.")
+	} else {
+		fmt.Printf("Scheduling Conflicts (%d):\n", len(report.Conflicts))
+		for _, c := range report.Conflicts {
+			fmt.Printf("  - %-20s (%s)\n", c.TaskName, c.Schedule)
+		}
+	}
+
+	if report.PeakConcurrency > 0 {
+		fmt.Println()
+		fmt.Printf("Peak Concurrency: %d tasks at %s\n", report.PeakConcurrency,
+			report.PeakTime.Format("15:04"))
+	}
+
+	if len(report.Suggestions) > 0 {
+		fmt.Println()
+		fmt.Println("Suggested Alternatives:")
+		for _, s := range report.Suggestions {
+			fmt.Printf("  - %-20s (%d conflict", s.Schedule, s.ConflictCount)
+			if s.ConflictCount != 1 {
+				fmt.Print("s")
+			}
+			fmt.Println(")")
+		}
+	}
+	fmt.Println()
+}
+
+// printImpactJSON outputs the impact report in JSON format.
+func printImpactJSON(report ImpactReport) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		log.Fatalf("failed to marshal JSON: %v", err)
+	}
+	fmt.Println(string(data))
+}

--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -1640,7 +1640,8 @@ Options:
   -s, --schedule cron     Cron schedule (e.g., "*/15 * * * *")
   -t, --template name    Use a template for task configuration
   -o, --once              Create a one-shot task (no schedule)
-  -n, --dry-run          Validate schedule without creating task
+  -n, --dry-run          Show impact analysis (conflicts, load) without creating task
+  --json                 Output impact analysis as JSON (with --dry-run)
   --pre-check cmd        Command to run before task execution
   --allowed-tools tools  Comma-separated list of allowed tools (e.g. "Bash,Read" or scoped "Bash(gh:*)", "Read(.claude/commands/*)")
   --max-concurrent n     Max concurrent runs (default: 1)
@@ -1941,6 +1942,7 @@ func taskCreateCmd(args []string) {
 	dryRun := false
 	strict := false
 	noOverlapCheck := false
+	dryRunJSON := false
 	templateName := ""
 	var dependsOn []string
 
@@ -1988,6 +1990,8 @@ func taskCreateCmd(args []string) {
 			onceFlag = true
 		case "-n", "--dry-run":
 			dryRun = true
+		case "--json":
+			dryRunJSON = true
 		case "--pre-check":
 			if i+1 >= len(args) {
 				log.Fatal("missing value for --pre-check")
@@ -2052,21 +2056,23 @@ func taskCreateCmd(args []string) {
 		scheduleSet = true
 	}
 
-	// Handle --dry-run: validate schedule without creating task.
+	// Handle --dry-run: show impact analysis without creating task.
 	if dryRun {
+		abs, err := filepath.Abs(".")
+		if err != nil {
+			log.Fatalf("bad path: %v", err)
+		}
+		var todos []project.Todo
 		if schedule != "" {
-			if _, err := cron.Parse(schedule); err != nil {
-				log.Fatalf("invalid cron expression: %s (%v)", schedule, err)
+			if proj, err := project.Load(abs); err == nil {
+				todos, _ = proj.LoadTodos()
 			}
-			// Show next run time
-			if p, err := cron.Parse(schedule); err == nil {
-				if next, err := p.Next(time.Now()); err == nil {
-					until := time.Until(next).Round(time.Minute)
-					fmt.Printf("Schedule is valid. Next run: %s (%s from now)\n", next.Format("Mon Jan 2 15:04:05"), until)
-				}
-			}
+		}
+		report := analyzeImpact(schedule, todos)
+		if dryRunJSON {
+			printImpactJSON(report)
 		} else {
-			fmt.Println("No schedule specified (one-shot task)")
+			printImpactReport(report)
 		}
 		return
 	}
@@ -2162,45 +2168,16 @@ func taskCreateCmd(args []string) {
 		log.Fatalf("failed to load project: %v", err)
 	}
 
-	// Check for schedule overlaps with existing tasks.
+	// Check for schedule overlaps with existing tasks using shared conflict detection.
 	if schedule != "" && !noOverlapCheck {
-		if newParser, parseErr := cron.Parse(schedule); parseErr == nil {
+		if _, parseErr := cron.Parse(schedule); parseErr == nil {
 			todos, _ := proj.LoadTodos()
-			now := time.Now().Truncate(time.Minute)
-			var overlapping []string
-			for _, t := range todos {
-				if t.Schedule == "" || t.Schedule == "persistent" || t.Disabled {
-					continue
+			conflicts := computeConflicts(schedule, todos)
+			if len(conflicts) > 0 {
+				var overlapping []string
+				for _, c := range conflicts {
+					overlapping = append(overlapping, fmt.Sprintf("%s (%s)", c.TaskName, c.Schedule))
 				}
-				existParser, err := cron.Parse(t.Schedule)
-				if err != nil {
-					continue
-				}
-				// Check next 30 occurrences for overlap within 1 minute
-				cur := now
-				for k := 0; k < 30; k++ {
-					newNext, e1 := newParser.Next(cur)
-					existNext, e2 := existParser.Next(cur)
-					if e1 != nil || e2 != nil {
-						break
-					}
-					diff := newNext.Sub(existNext)
-					if diff < 0 {
-						diff = -diff
-					}
-					if diff <= time.Minute {
-						name := strings.TrimSuffix(t.Name, ".md")
-						overlapping = append(overlapping, fmt.Sprintf("%s (%s)", name, t.Schedule))
-						break
-					}
-					if newNext.Before(existNext) {
-						cur = newNext
-					} else {
-						cur = existNext
-					}
-				}
-			}
-			if len(overlapping) > 0 {
 				if strict {
 					fmt.Fprintf(os.Stderr, "Error: Schedule overlaps with %d existing task(s):\n", len(overlapping))
 					for _, o := range overlapping {
@@ -2212,14 +2189,14 @@ func taskCreateCmd(args []string) {
 				}
 				// Non-strict: warn but continue
 				severity := "Note"
-				if len(overlapping) >= 3 {
+				if len(conflicts) >= 3 {
 					severity = "Warning"
 				}
-				fmt.Fprintf(os.Stderr, "%s: This schedule overlaps with %d existing task(s) that run at similar times:\n", severity, len(overlapping))
+				fmt.Fprintf(os.Stderr, "%s: This schedule overlaps with %d existing task(s) that run at similar times:\n", severity, len(conflicts))
 				for _, o := range overlapping {
 					fmt.Fprintf(os.Stderr, "  - %s\n", o)
 				}
-				suggestStagger(schedule, len(overlapping))
+				suggestStagger(schedule, len(conflicts))
 				fmt.Fprintln(os.Stderr)
 			}
 		}

--- a/specs/016-dryrun-impact/checklists/requirements.md
+++ b/specs/016-dryrun-impact/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Dry-Run Impact Analysis
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for planning.
+- Assumptions: cost estimation excluded from scope (issue mentions it but no cost model exists in the codebase). Focus is on schedule conflicts and worker load.

--- a/specs/016-dryrun-impact/contracts/cli.md
+++ b/specs/016-dryrun-impact/contracts/cli.md
@@ -1,0 +1,76 @@
+# CLI Contract: Dry-Run Impact Analysis
+
+## Enhanced `anvil add --dry-run`
+
+### Human-Readable Output
+
+```
+$ anvil add -s "0 9 * * *" "New task" --dry-run
+
+Impact Analysis
+────────────────────────────────────────
+Schedule:   0 9 * * *
+Next Run:   Mon Mar 2 09:00:00 (3h from now)
+
+Scheduling Conflicts (3):
+  - fetch-data       (0 9 * * *)
+  - process-data     (0 9 * * *)
+  - daily-report     (0 9 * * 1-5)
+
+Peak Concurrency: 4 tasks at 09:00
+
+Suggested Alternatives:
+  - 0 10 * * *  (0 conflicts)
+  - 0 8 * * *   (1 conflict)
+  - 30 9 * * *  (0 conflicts)
+```
+
+### No Conflicts Output
+
+```
+$ anvil add -s "0 3 * * *" "Night task" --dry-run
+
+Impact Analysis
+────────────────────────────────────────
+Schedule:   0 3 * * *
+Next Run:   Tue Mar 3 03:00:00 (18h from now)
+
+No scheduling conflicts.
+```
+
+### One-Shot Task Output
+
+```
+$ anvil add --once "One-time task" --dry-run
+
+No schedule specified (one-shot task).
+```
+
+### JSON Output
+
+```
+$ anvil add -s "0 9 * * *" "New task" --dry-run --json
+
+{
+  "schedule": "0 9 * * *",
+  "valid": true,
+  "next_run": "2026-03-02T09:00:00Z",
+  "conflicts": [
+    {"task": "fetch-data", "schedule": "0 9 * * *", "overlap_time": "2026-03-02T09:00:00Z"},
+    {"task": "process-data", "schedule": "0 9 * * *", "overlap_time": "2026-03-02T09:00:00Z"}
+  ],
+  "peak_concurrency": 3,
+  "peak_time": "2026-03-02T09:00:00Z",
+  "suggestions": [
+    {"schedule": "0 10 * * *", "conflicts": 0, "description": "Shift +1 hour"},
+    {"schedule": "0 8 * * *", "conflicts": 1, "description": "Shift -1 hour"}
+  ]
+}
+```
+
+## Flag Changes
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| --dry-run | -n | bool | false | Show impact analysis without creating task |
+| --json | | bool | false | Output impact analysis in JSON format (only with --dry-run) |

--- a/specs/016-dryrun-impact/data-model.md
+++ b/specs/016-dryrun-impact/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Dry-Run Impact Analysis
+
+## Entities
+
+### ImpactReport
+The result of analyzing a proposed schedule against existing tasks.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Schedule | string | The proposed cron expression |
+| IsValid | bool | Whether the cron expression is syntactically valid |
+| ParseError | string | Error message if schedule is invalid |
+| NextRun | time.Time | Next firing time for the proposed schedule |
+| Conflicts | []Conflict | List of tasks with overlapping schedules |
+| PeakConcurrency | int | Maximum number of tasks (including proposed) running at same time |
+| PeakTime | time.Time | The time when peak concurrency occurs |
+| Suggestions | []Suggestion | Alternative schedules with fewer conflicts |
+
+### Conflict
+A single scheduling conflict between the proposed task and an existing task.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| TaskName | string | Name of the conflicting existing task |
+| Schedule | string | Cron schedule of the conflicting task |
+| OverlapTime | time.Time | First detected overlap time |
+
+### Suggestion
+An alternative schedule that reduces conflicts.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Schedule | string | The suggested cron expression |
+| ConflictCount | int | Number of conflicts with this schedule |
+| Description | string | Human-readable description of the change |
+
+## State Transitions
+None — ImpactReport is computed and displayed, not persisted.
+
+## Relationships
+- ImpactReport contains 0..N Conflicts
+- ImpactReport contains 0..3 Suggestions
+- Conflicts reference existing Todo entities by name

--- a/specs/016-dryrun-impact/plan.md
+++ b/specs/016-dryrun-impact/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Dry-Run Impact Analysis
+
+**Branch**: `016-dryrun-impact` | **Date**: 2026-02-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/016-dryrun-impact/spec.md`
+
+## Summary
+
+Enhance the existing `anvil add --dry-run` command to show a full impact analysis including scheduling conflicts with existing tasks, peak worker concurrency at proposed time slots, and alternative schedule suggestions. The existing overlap detection logic (main.go:2165-2226) will be refactored into reusable functions in a new `cmd/anvil/impact.go` file.
+
+## Technical Context
+
+**Language/Version**: Go 1.24.6
+**Primary Dependencies**: internal/cron (schedule parsing, Next()), internal/project (Todo, LoadTodos)
+**Storage**: N/A (stateless — reads existing tasks, produces report, no persistence)
+**Testing**: go test ./cmd/anvil/ (existing pattern)
+**Target Platform**: CLI (macOS, Linux)
+**Project Type**: CLI tool
+**Performance Goals**: < 2 seconds for 100 tasks
+**Constraints**: Must preserve existing --dry-run behavior (schedule validation + next run display)
+**Scale/Scope**: Projects with up to 100 tasks
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution is a template (not project-specific). No gates to evaluate.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-dryrun-impact/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── cli.md           # CLI contract
+└── tasks.md             # Phase 2 output (speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/anvil/
+├── main.go              # Modified: --dry-run flow calls impact analysis, --json flag
+├── impact.go            # NEW: impact analysis functions
+└── dryrun.go            # Unchanged (existing task dry-run)
+```
+
+**Structure Decision**: Single new file (impact.go) in the existing cmd/anvil/ package. Keeps impact analysis self-contained while sharing access to project types and cron parser.
+
+## Complexity Tracking
+
+No constitution violations — no new dependencies, no new packages, minimal new code.

--- a/specs/016-dryrun-impact/quickstart.md
+++ b/specs/016-dryrun-impact/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Dry-Run Impact Analysis
+
+## Overview
+The dry-run impact analysis enhances `anvil add --dry-run` to show scheduling conflicts, worker load, and alternative schedule suggestions before adding a task.
+
+## Usage
+
+### Basic Impact Analysis
+```bash
+anvil add -s "0 9 * * *" "Daily report" --dry-run
+```
+
+### JSON Output
+```bash
+anvil add -s "0 9 * * *" "Daily report" --dry-run --json
+```
+
+### One-Shot Task (no impact analysis)
+```bash
+anvil add --once "Migrate database" --dry-run
+```
+
+## What You See
+1. **Schedule validation** — confirms cron syntax is valid and shows next run time
+2. **Scheduling conflicts** — lists existing tasks that fire at the same times
+3. **Peak concurrency** — shows maximum concurrent tasks at the busiest time slot
+4. **Suggested alternatives** — offers 2-3 nearby schedules with fewer conflicts
+
+## When to Use
+- Before adding any scheduled task to check for bottlenecks
+- When planning task schedules across a project
+- To find optimal time slots with minimal contention

--- a/specs/016-dryrun-impact/research.md
+++ b/specs/016-dryrun-impact/research.md
@@ -1,0 +1,36 @@
+# Research: Dry-Run Impact Analysis
+
+## Decision 1: Reuse Existing Overlap Detection
+- **Decision**: Refactor existing overlap detection code (main.go:2165-2226) into a reusable function, then call it from both the normal add flow and the enhanced dry-run flow.
+- **Rationale**: The overlap detection algorithm already works correctly (30 future occurrences, 1-minute tolerance). Duplicating it would create maintenance burden.
+- **Alternatives considered**: (a) Writing new overlap code from scratch — rejected because existing algorithm is proven. (b) Moving to a separate package — rejected as over-engineering for a CLI command.
+
+## Decision 2: Time Window for Conflict Analysis
+- **Decision**: Use a 24-hour window for enumerating firing times to detect conflicts and compute worker load.
+- **Rationale**: 24 hours covers all daily patterns. Weekly/monthly patterns would need longer windows but 24h is sufficient for the most common scheduling scenarios and keeps computation fast.
+- **Alternatives considered**: (a) 7-day window — rejected because it's slower and most schedules repeat daily. (b) 30 occurrences (current approach) — reused as-is for per-task overlap check.
+
+## Decision 3: Worker Load Calculation
+- **Decision**: Enumerate all active tasks' next-24h firing times into a time-slot map (minute resolution), then count concurrent tasks per slot.
+- **Rationale**: Gives accurate concurrency picture. Minute resolution matches cron granularity.
+- **Alternatives considered**: (a) Hour-resolution buckets — too coarse, misses minute-level conflicts. (b) Per-second resolution — unnecessary given cron's minute granularity.
+
+## Decision 4: Alternative Schedule Suggestions
+- **Decision**: Generate alternatives by shifting the proposed schedule by +/- 1-3 hours and checking which shifts have fewer conflicts. Only suggest alternatives with strictly fewer conflicts.
+- **Rationale**: Simple heuristic that covers the most common fix (shift time). More complex approaches (genetic algorithms, constraint solvers) are over-engineering.
+- **Alternatives considered**: (a) Random schedule generation — unpredictable. (b) Spread-across-day suggestions — too opinionated about user intent.
+
+## Decision 5: JSON Output Format
+- **Decision**: Add --json flag to anvil add --dry-run that outputs a structured JSON object with schedule info, conflicts, worker load, and suggestions.
+- **Rationale**: Consistent with existing --json patterns in dryrun.go and other commands.
+- **Alternatives considered**: None — JSON output is standard practice in this codebase.
+
+## Decision 6: Implementation Location
+- **Decision**: Add a new file cmd/anvil/impact.go for the impact analysis logic, keeping dryrun.go for existing task dry-run and main.go cleaner.
+- **Rationale**: Separates concerns. The impact analysis is a distinct feature from task config validation (dryrun.go).
+- **Alternatives considered**: (a) Add to dryrun.go — rejected because dryrun.go handles existing task validation, not new-task impact. (b) Add inline in main.go — rejected because main.go is already very large.
+
+## Decision 7: Cost Estimation
+- **Decision**: Exclude cost estimation from scope. The issue mentions "Monthly Cost: +$15.00" but there is no cost model in the codebase.
+- **Rationale**: No pricing data, no cost-per-run metric, no billing integration exists. Adding a cost model is a separate feature.
+- **Alternatives considered**: (a) Add placeholder cost model — rejected as speculative and misleading.

--- a/specs/016-dryrun-impact/spec.md
+++ b/specs/016-dryrun-impact/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Dry-Run Impact Analysis
+
+**Feature Branch**: `016-dryrun-impact`
+**Created**: 2026-02-28
+**Status**: Draft
+**Input**: User description: "Add task dry-run impact analysis before adding new tasks (#319)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Schedule Conflict Detection (Priority: P1)
+
+A user is adding a new scheduled task and wants to know if it will conflict with existing tasks that run at the same time. Before committing the task, they see which existing tasks share the same scheduled time slots.
+
+**Why this priority**: Schedule conflicts are the most common source of worker bottlenecks and the most actionable piece of information when deciding whether to add a task.
+
+**Independent Test**: Can be fully tested by running `anvil add -s "0 9 * * *" "Test task" --dry-run` against a project with existing tasks scheduled at 09:00, and verifying the conflict list appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with tasks scheduled at "0 9 * * *", **When** user runs `anvil add -s "0 9 * * *" "New task" --dry-run`, **Then** the output lists all conflicting tasks and their schedules.
+2. **Given** a project with no scheduling conflicts, **When** user runs `anvil add -s "0 3 * * *" "Night task" --dry-run`, **Then** the output shows "No scheduling conflicts".
+3. **Given** a task with a complex schedule like "*/15 * * * *", **When** user runs `anvil add -s "0 * * * *" "Hourly task" --dry-run`, **Then** the output shows the 15-minute task as a conflict (since it fires at the top of each hour too).
+
+---
+
+### User Story 2 - Worker Load Estimate (Priority: P2)
+
+A user wants to understand how adding a new task will affect overall worker utilization at the scheduled times. The dry-run shows how many tasks are already scheduled in the same time windows and the percentage load increase.
+
+**Why this priority**: Worker load gives users a broader view of system health beyond just direct conflicts, helping them make informed scheduling decisions.
+
+**Independent Test**: Can be tested by running `anvil add --dry-run` and verifying the worker load statistics appear alongside the conflict data.
+
+**Acceptance Scenarios**:
+
+1. **Given** 5 tasks scheduled at 09:00, **When** user runs `anvil add -s "0 9 * * *" "New task" --dry-run`, **Then** the output shows the number of concurrent tasks at that time slot (e.g., "6 tasks at 09:00").
+2. **Given** a one-shot task (no schedule), **When** user runs `anvil add --once "One-time task" --dry-run`, **Then** the output shows schedule validation only (no conflict or load analysis).
+
+---
+
+### User Story 3 - Alternative Schedule Suggestions (Priority: P3)
+
+When conflicts are detected, the system suggests alternative schedules that avoid the congested time slots, helping users spread their workload more evenly.
+
+**Why this priority**: This is a convenience enhancement that builds on conflict detection -- useful but not essential for the core dry-run experience.
+
+**Independent Test**: Can be tested by running `anvil add --dry-run` with a conflicting schedule and verifying that alternative times are suggested.
+
+**Acceptance Scenarios**:
+
+1. **Given** conflicts at "0 9 * * *", **When** dry-run detects conflicts, **Then** it suggests 2-3 nearby time slots with fewer conflicts (e.g., "0 10 * * *", "30 8 * * *").
+2. **Given** no conflicts detected, **When** dry-run completes, **Then** no alternative suggestions are shown.
+
+---
+
+### Edge Cases
+
+- What happens when the schedule is invalid (bad cron syntax)? The existing validation error is shown and no impact analysis is performed.
+- What happens when there are no existing tasks in the project? The output shows "No existing tasks to compare against" and skips conflict analysis.
+- What happens with persistent tasks (schedule = "persistent")? They are excluded from time-based conflict analysis since they don't follow cron schedules.
+- What happens with disabled tasks? Disabled tasks are excluded from conflict analysis since they won't actually run.
+- What happens with one-shot tasks (--once)? One-shot tasks have no schedule, so the output shows schedule validation only without conflict or load analysis.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST extend the existing `anvil add --dry-run` to show impact analysis including scheduling conflicts when a schedule is provided.
+- **FR-002**: System MUST compare the new task's schedule against all active (non-disabled) scheduled tasks in the project to detect time overlaps.
+- **FR-003**: System MUST display a list of conflicting tasks with their names and schedules when overlaps are detected.
+- **FR-004**: System MUST show the total number of tasks that would run concurrently at the proposed schedule times.
+- **FR-005**: System MUST suggest 2-3 alternative time slots with fewer conflicts when conflicts are detected.
+- **FR-006**: System MUST preserve the existing schedule validation behavior (cron syntax checking, next run time display) as part of the enhanced dry-run.
+- **FR-007**: System MUST skip conflict analysis for one-shot tasks (--once) and only show schedule validation.
+- **FR-008**: System MUST exclude disabled tasks and persistent tasks from conflict analysis.
+- **FR-009**: System MUST support `--json` flag on `anvil add --dry-run` to output impact analysis in machine-readable JSON format.
+
+### Key Entities
+
+- **Schedule Conflict**: A pair of tasks whose cron schedules produce overlapping execution times within a comparison window.
+- **Time Slot**: A specific minute-resolution time point where one or more tasks are scheduled to fire within the next 24 hours.
+- **Impact Report**: The collection of conflicts, worker load data, and suggested alternatives produced by the dry-run analysis.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can see all scheduling conflicts before adding a task, in under 2 seconds for projects with up to 100 tasks.
+- **SC-002**: Conflict detection correctly identifies overlapping schedules by comparing next-24-hour firing times.
+- **SC-003**: Alternative schedule suggestions reduce conflicts to zero or fewer conflicts than the original schedule.
+- **SC-004**: The dry-run output is clear enough that users can make an informed add/skip decision without running additional commands.

--- a/specs/016-dryrun-impact/tasks.md
+++ b/specs/016-dryrun-impact/tasks.md
@@ -1,0 +1,145 @@
+# Tasks: Dry-Run Impact Analysis
+
+**Input**: Design documents from `/specs/016-dryrun-impact/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: No tests explicitly requested in spec. Test tasks omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the new impact.go file and establish the data structures
+
+- [ ] T001 Create cmd/anvil/impact.go with ImpactReport, Conflict, and Suggestion structs per data-model.md
+- [ ] T002 Add --json flag parsing to taskCreateCmd dry-run flow in cmd/anvil/main.go (alongside existing --dry-run/-n flag)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extract existing overlap detection into reusable functions
+
+- [ ] T003 Extract overlap detection logic from cmd/anvil/main.go (lines 2165-2226) into a reusable function computeConflicts(schedule string, todos []project.Todo) []Conflict in cmd/anvil/impact.go
+- [ ] T004 Refactor the original overlap detection in taskCreateCmd (main.go) to call the new computeConflicts function instead of inline code
+
+**Checkpoint**: Existing overlap detection works identically through the refactored function
+
+---
+
+## Phase 3: User Story 1 - Schedule Conflict Detection (Priority: P1) MVP
+
+**Goal**: anvil add --dry-run shows scheduling conflicts with existing tasks
+
+**Independent Test**: Run anvil add -s "0 9 * * *" "Test" --dry-run against a project with existing 09:00 tasks and verify conflicts are listed
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Implement analyzeImpact(schedule string, todos []project.Todo) ImpactReport function in cmd/anvil/impact.go that validates schedule, computes conflicts, and populates ImpactReport
+- [ ] T006 [US1] Implement printImpactReport(report ImpactReport) function in cmd/anvil/impact.go for human-readable output per contracts/cli.md format
+- [ ] T007 [US1] Update the --dry-run block in taskCreateCmd (cmd/anvil/main.go) to load todos, call analyzeImpact, and call printImpactReport instead of the current minimal validation
+
+**Checkpoint**: anvil add --dry-run shows schedule validation + conflict list
+
+---
+
+## Phase 4: User Story 2 - Worker Load Estimate (Priority: P2)
+
+**Goal**: anvil add --dry-run shows peak concurrency at proposed time slots
+
+**Independent Test**: Run anvil add --dry-run with a schedule that overlaps multiple tasks and verify peak concurrency count appears
+
+### Implementation for User Story 2
+
+- [ ] T008 [US2] Implement computePeakConcurrency(schedule string, todos []project.Todo) (peakCount int, peakTime time.Time) in cmd/anvil/impact.go that enumerates next-24h firing times for all active tasks and finds the busiest time slot
+- [ ] T009 [US2] Integrate peak concurrency results into analyzeImpact and printImpactReport in cmd/anvil/impact.go
+
+**Checkpoint**: anvil add --dry-run shows conflicts + peak concurrency
+
+---
+
+## Phase 5: User Story 3 - Alternative Schedule Suggestions (Priority: P3)
+
+**Goal**: When conflicts exist, suggest 2-3 alternative schedules with fewer conflicts
+
+**Independent Test**: Run anvil add --dry-run with a conflicting schedule and verify alternative suggestions appear
+
+### Implementation for User Story 3
+
+- [ ] T010 [US3] Implement suggestAlternatives(schedule string, todos []project.Todo, currentConflicts int) []Suggestion in cmd/anvil/impact.go that shifts the proposed schedule by +/- 1-3 hours and returns alternatives with fewer conflicts
+- [ ] T011 [US3] Integrate suggestions into analyzeImpact and printImpactReport in cmd/anvil/impact.go
+
+**Checkpoint**: Full impact analysis with conflicts + concurrency + suggestions
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: JSON output and edge case handling
+
+- [ ] T012 Implement printImpactJSON(report ImpactReport) function in cmd/anvil/impact.go for JSON output per contracts/cli.md format
+- [ ] T013 Wire --json flag in taskCreateCmd (cmd/anvil/main.go) to call printImpactJSON instead of printImpactReport when --json and --dry-run are both set
+- [ ] T014 Handle edge cases in analyzeImpact: no existing tasks, one-shot tasks (no schedule), invalid cron syntax — per spec.md edge cases section
+- [ ] T015 Update help text in addCmd (cmd/anvil/main.go) to document the enhanced --dry-run and --json flags
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (T001 must exist before T003)
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (T003, T004)
+- **User Story 2 (Phase 4)**: Depends on Phase 3 (T005 analyzeImpact must exist)
+- **User Story 3 (Phase 5)**: Depends on Phase 3 (T005 analyzeImpact must exist)
+- **Polish (Phase 6)**: Depends on Phase 3 (T005, T006 must exist for JSON variant)
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Core — no other story dependencies
+- **User Story 2 (P2)**: Extends US1's analyzeImpact function
+- **User Story 3 (P3)**: Extends US1's analyzeImpact function, independent of US2
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- US2 (Phase 4) and US3 (Phase 5) can theoretically run in parallel (independent features extending same function), but sequential is simpler since both modify impact.go
+- T012 and T015 can run in parallel (different files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T004)
+3. Complete Phase 3: User Story 1 (T005-T007)
+4. **STOP and VALIDATE**: Test `anvil add -s "0 9 * * *" "Test" --dry-run` shows conflicts
+5. Continue with remaining stories
+
+### Incremental Delivery
+
+1. Setup + Foundational → Refactored overlap detection
+2. User Story 1 → Conflicts shown in dry-run (MVP!)
+3. User Story 2 → Peak concurrency added
+4. User Story 3 → Alternative suggestions added
+5. Polish → JSON output + edge cases + help text
+
+---
+
+## Notes
+
+- All implementation is in cmd/anvil/ package (impact.go + main.go modifications)
+- No new dependencies needed — uses existing internal/cron and internal/project
+- Total tasks: 15
+- US1: 3 tasks, US2: 2 tasks, US3: 2 tasks, Setup: 2 tasks, Foundation: 2 tasks, Polish: 4 tasks


### PR DESCRIPTION
## Summary
- Enhanced `anvil add --dry-run` with full impact analysis showing scheduling conflicts, peak concurrency, and alternative schedule suggestions
- Refactored overlap detection into reusable `computeConflicts()` function in new `cmd/anvil/impact.go`
- Added `--json` flag for machine-readable impact analysis output

## Test plan
- [ ] Run `anvil add -s "0 9 * * *" "Test" --dry-run` against a project with existing 09:00 tasks — verify conflicts listed
- [ ] Run `anvil add -s "0 3 * * *" "Test" --dry-run` with no conflicts — verify "No scheduling conflicts"
- [ ] Run `anvil add --once "Test" --dry-run` — verify one-shot message
- [ ] Run `anvil add -s "0 9 * * *" "Test" --dry-run --json` — verify JSON output
- [ ] Run `anvil add -s "0 9 * * *" "Test"` (without --dry-run) — verify overlap detection still works via refactored `computeConflicts()`
- [ ] Run `go build ./...` and `go test ./...` — all pass

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)